### PR TITLE
Fix -W compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ add_compile_options(
         -Wconversion -Wshadow
         -Wdouble-promotion -Wnull-dereference
         -Wnon-virtual-dtor
+        -Werror
         -fstack-protector-strong
         -D_FORTIFY_SOURCE=2
         -fvisibility=hidden

--- a/common/fsm/core/transition.hpp
+++ b/common/fsm/core/transition.hpp
@@ -1,9 +1,23 @@
 #pragma once
+#include <cstdint>
 
 namespace demiplane::fsm {
     class Transition {
     public:
         Transition(const uint32_t from, const uint32_t to) : from_(from), to_(to) {}
+        [[nodiscard]] uint32_t get_from() const {
+            return from_;
+        }
+        void set_from(const uint32_t from) {
+            from_ = from;
+        }
+        [[nodiscard]] uint32_t get_to() const {
+            return to_;
+        }
+        void set_to(const uint32_t to) {
+            to_ = to;
+        }
+
     private:
         uint32_t from_;
         uint32_t to_;

--- a/common/gears/utilities/include/gears_utils.hpp
+++ b/common/gears/utilities/include/gears_utils.hpp
@@ -6,7 +6,11 @@ namespace demiplane::gears {
     consteval void unused_value(const V& value) {
         static_cast<void>(value);
     }
-
+    template <typename V, typename... Rest>
+    consteval void unused_value(const V& value, const Rest&... rest) {
+        static_cast<void>(value);
+        unused_value(rest...); // Recursively process remaining arguments
+    }
     template <class T = void>
     constexpr void unreachable() {
         static_assert(dependent_false_v<T>, "Unreachable branch reached.");

--- a/common/scroll/core/include/entry/light_entry.hpp
+++ b/common/scroll/core/include/entry/light_entry.hpp
@@ -18,6 +18,8 @@ namespace demiplane::scroll {
             return formatter.str();
         }
         static bool comp(const LightEntry& lhs, const LightEntry& rhs) {
+            gears::unused_value(lhs, rhs);
+            static_assert(true, "Can not be sorted");
             throw std::logic_error("Can not be sorted");
         }
     };

--- a/common/scroll/logger/include/file_logger.hpp
+++ b/common/scroll/logger/include/file_logger.hpp
@@ -243,7 +243,7 @@ namespace demiplane::scroll {
         std::ofstream file_stream_;
         moodycamel::ConcurrentQueue<EntryType> queue_;
 
-        std::atomic<int> pending_entries_{0}; // entries enqueued but not yet written
+        std::atomic<std::size_t> pending_entries_{0}; // entries enqueued but not yet written
         std::atomic<bool> accepting_{true}; // producers allowed to enqueue?
         std::atomic<bool> running_{true}; // writer loop keeps spinning?
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,8 +14,7 @@ add_executable(${PROJECT_NAME}.Tests.Sandbox
 )
 target_link_libraries(${PROJECT_NAME}.Tests.Sandbox
         PRIVATE
-#        Demiplane::Component::Nexus
-#        Demiplane::Scroll
+        Demiplane::Common::Gears
 )
 
 add_subdirectory(unit_tests)

--- a/tests/codesandbox/main.cpp
+++ b/tests/codesandbox/main.cpp
@@ -1,10 +1,11 @@
 
 #include <atomic>
+#include <demiplane/gears>
 #include <iostream>
+#include <utility>
 
 class X {
 public:
-
 };
 
 int main() {
@@ -12,5 +13,6 @@ int main() {
     std::cout << x.fetch_sub(5, std::memory_order::release);
     std::cout << x << std::endl;
     X x1;
+    demiplane::gears::unused_value(std::as_const(x1));
     return 0;
 }

--- a/tests/unit_tests/scroll/logger/file_logger_test.cpp
+++ b/tests/unit_tests/scroll/logger/file_logger_test.cpp
@@ -196,15 +196,16 @@ parse_sec_ms(std::string_view line)
 void multithread_write(const std::shared_ptr<demiplane::scroll::FileLogger<demiplane::scroll::DetailedEntry>> &file_logger) {
     std::vector<std::thread> threads;
     // Launch multiple threads to acquire and release objects
-    int t_num = 20;
-    int r_num = 50000;
+    std::size_t t_num = 20;
+    std::size_t r_num = 50000;
     std::chrono::milliseconds process_time{1};
+    demiplane::gears::unused_value(process_time);
     threads.reserve(t_num);
     demiplane::chrono::PrintingStopwatch<> twp;
     twp.start();
-    for (int i = 0; i < t_num; ++i) {
+    for (std::size_t i = 0; i < t_num; ++i) {
         threads.emplace_back([&] {
-            for (int j = 0; j < r_num; ++j) {
+            for (std::size_t j = 0; j < r_num; ++j) {
                 std::string msg = "MSG" + std::to_string(j);
                 const auto entry = demiplane::scroll::make_entry<demiplane::scroll::DetailedEntry>(
                     demiplane::scroll::INF, msg , std::source_location::current());
@@ -245,7 +246,7 @@ void multithread_write(const std::shared_ptr<demiplane::scroll::FileLogger<demip
     }
 
     std::cout << "Non-monotonic lines: " << monotonic_errors <<  " " << total_lines << '\n';
-    std::cout << "Non-monotonic lines%: " << static_cast<double>(100*monotonic_errors)/(t_num*r_num) << '\n';
+    std::cout << "Non-monotonic lines%: " << static_cast<double>(100*monotonic_errors)/(static_cast<double>(t_num) * static_cast<double>(r_num)) << '\n';
 }
 
 TEST_F(FileLoggerTest, MultithreadWrite) {

--- a/tests/unit_tests/stopwatch/test_stopwatch.cpp
+++ b/tests/unit_tests/stopwatch/test_stopwatch.cpp
@@ -102,7 +102,7 @@ TEST_F(StopwatchTest, AverageDelta) {
 // Test the new measure function
 TEST_F(StopwatchTest, MeasureLambda) {
     // Measure a lambda that sleeps for 50ms
-    auto duration = stopwatch.measure([this]() { sleepFor(50); });
+    auto duration = stopwatch.measure([]() { sleepFor(50); });
 
     // Check that the duration is approximately 50ms
     EXPECT_GE(duration.count(), 45);
@@ -111,15 +111,15 @@ TEST_F(StopwatchTest, MeasureLambda) {
 
 // Test measure with complex logic
 TEST_F(StopwatchTest, MeasureComplexLogic) {
-    volatile long long result = 0;
+    long long result = 0;
 
-    const auto duration = stopwatch.measure([&result]() {
+    const auto duration = stopwatch.measure([&result] {
         // Do some computational work
         std::uniform_int_distribution dist(0, 5);
-        for (volatile long long i = 0; i < 10000; i++) {
+        for (std::size_t i = 0; i < 10000; ++i) {
             std::random_device rd;
             std::mt19937 gen(rd());
-            result += (dist(gen));
+            result += dist(gen);
         }
     });
 
@@ -133,7 +133,7 @@ TEST_F(StopwatchTest, MeasureComplexLogic) {
 // Test measure with function reference
 TEST_F(StopwatchTest, MeasureFunctionReference) {
     // Define a function to be measured
-    std::function<void()> testFunc = [this]() { sleepFor(20); };
+    std::function<void()> testFunc = []() { sleepFor(20); };
 
     auto duration = stopwatch.measure(testFunc);
 
@@ -145,9 +145,9 @@ TEST_F(StopwatchTest, MeasureFunctionReference) {
 // Test measure with multiple calls
 TEST_F(StopwatchTest, MeasureMultipleCalls) {
     // Measure multiple different durations
-    auto d1 = stopwatch.measure([this]() { sleepFor(10); });
-    auto d2 = stopwatch.measure([this]() { sleepFor(20); });
-    auto d3 = stopwatch.measure([this]() { sleepFor(30); });
+    auto d1 = stopwatch.measure([]() { sleepFor(10); });
+    auto d2 = stopwatch.measure([]() { sleepFor(20); });
+    auto d3 = stopwatch.measure([]() { sleepFor(30); });
 
     // Each duration should be approximately its sleep time
     EXPECT_GE(d1.count(), 5);
@@ -168,7 +168,7 @@ TEST_F(StopwatchTest, MeasureDoesntChangeFlags) {
     auto flagsBefore = stopwatch.get_flags().size();
 
     // Measure something
-    stopwatch.measure([this]() { sleepFor(10); });
+    stopwatch.measure([] { sleepFor(10); });
 
     auto flagsAfter = stopwatch.get_flags().size();
 


### PR DESCRIPTION
This pull request addresses and fixes compiler warnings generated with the `-W` flag. This cleanup improves overall code quality and ensures compatibility with stricter compilation standards.

- [x] Tests have been added or updated.