### PR TITLE
Add Outcome construct and improve error handling utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,12 @@ Testing/
 *.pdb
 *.opendb
 
+# ===========================
+# Private specific
+# ===========================
+tests/codesandbox/
+
+
 # AI
 /CLAUDE.md
 .claude/

--- a/common/gears/CMakeLists.txt
+++ b/common/gears/CMakeLists.txt
@@ -5,6 +5,7 @@ set(DMP_GEARS ${DMP_COMMON}.Gears)
 ##############################################################################
 add_library(${DMP_GEARS}.Result INTERFACE
         result/include/gears_result.hpp
+        result/include/gears_outcome.hpp
 )
 target_include_directories(${DMP_GEARS}.Result INTERFACE
         result/include/

--- a/common/gears/CMakeLists.txt
+++ b/common/gears/CMakeLists.txt
@@ -4,7 +4,7 @@ set(DMP_GEARS ${DMP_COMMON}.Gears)
 # Result class for convenient handling
 ##############################################################################
 add_library(${DMP_GEARS}.Result INTERFACE
-        result/include/gears_result.hpp
+        result/include/gears_exception_result.hpp
         result/include/gears_outcome.hpp
 )
 target_include_directories(${DMP_GEARS}.Result INTERFACE
@@ -49,6 +49,8 @@ target_include_directories(${DMP_GEARS}.Utilities INTERFACE
 add_combined_library(${DMP_GEARS}
         DIRECTORIES
         export
+        SOURCES
+        export/demiplane/gears
         LIBRARIES
         ${DMP_GEARS}.Result
         ${DMP_GEARS}.MetaProgramming

--- a/common/gears/export/demiplane/gears
+++ b/common/gears/export/demiplane/gears
@@ -5,7 +5,7 @@
 #include "gears_exceptions.hpp"
 #include "gears_hash.hpp"
 #include "gears_macros.hpp"
-#include "gears_result.hpp"
+#include "gears_exception_result.hpp"
 #include "gears_templates.hpp"
 #include "gears_types.hpp"
 #include "gears_utils.hpp"

--- a/common/gears/meta_programming/include/gears_concepts.hpp
+++ b/common/gears/meta_programming/include/gears_concepts.hpp
@@ -22,4 +22,11 @@ namespace demiplane::gears {
 
     template <typename T>
     concept IsDuration = std::chrono::__is_duration_v<T>;
+
+    template <typename T, typename... Args>
+    concept OneOf = (std::is_same_v<Args, T> || ...);
+
+    template <typename T, typename... Args>
+    concept OneOfDecayed = (std::is_same_v<std::remove_cvref_t<Args>, T> || ...);
+
 }  // namespace demiplane::gears

--- a/common/gears/meta_programming/include/gears_templates.hpp
+++ b/common/gears/meta_programming/include/gears_templates.hpp
@@ -111,4 +111,12 @@ namespace demiplane::gears {
     constexpr bool has_exact_arg_type() {
         return (std::is_same_v<Args, T> || ...);
     }
+
+    // Helper for overloaded visitor pattern
+    template<class... Ts>
+    struct overloaded : Ts... {
+        using Ts::operator()...;
+    };
+    template<class... Ts>
+    overloaded(Ts...) -> overloaded<Ts...>;
 }  // namespace demiplane::gears

--- a/common/gears/result/include/gears_exception_result.hpp
+++ b/common/gears/result/include/gears_exception_result.hpp
@@ -8,7 +8,7 @@
 
 namespace demiplane::gears {
     template <typename T>
-    class Result {
+    class ExceptionResult {
     public:
         /* ───── state ────────────────────────────────────────────── */
         [[nodiscard]] bool has_value() const noexcept {
@@ -52,10 +52,10 @@ namespace demiplane::gears {
 
         /* ───── factory helpers (optional) ───────────────────────── */
         template <typename... Args>
-        static Result success(Args&&... args)
+        static ExceptionResult success(Args&&... args)
             requires std::is_constructible_v<T, Args&&...>
         {
-            Result r;
+            ExceptionResult r;
             r.value_.emplace(std::forward<Args>(args)...);
             return r;
         }
@@ -90,7 +90,7 @@ namespace demiplane::gears {
     };
 
     template <>
-    class Result<void> {
+    class ExceptionResult<void> {
     public:
         [[nodiscard]] bool has_value() const noexcept {
             return !error_;

--- a/common/gears/result/include/gears_outcome.hpp
+++ b/common/gears/result/include/gears_outcome.hpp
@@ -1,25 +1,25 @@
 #pragma once
 
-#include <variant>
+#include <functional>
 #include <type_traits>
+#include <variant>
+
 #include "gears_concepts.hpp"
 #include "gears_templates.hpp"
+
 namespace demiplane::gears {
-
-    // Forward declaration
-    template <typename T, typename... Errors>
-    class Outcome;
-
     // Error wrapper for implicit construction
     template <typename E>
     struct ErrorTag {
         E error;
-        explicit ErrorTag(E&& e) : error(std::forward<E>(e)) {}
+        constexpr explicit ErrorTag(E e)
+            : error(std::move(e)) {
+        }
     };
 
     // Helper to deduce error type
     template <typename E>
-    ErrorTag<std::decay_t<E>> Err(E&& e) {
+    constexpr ErrorTag<std::decay_t<E>> Err(E&& e) {
         return ErrorTag<std::decay_t<E>>{std::forward<E>(e)};
     }
 
@@ -27,41 +27,60 @@ namespace demiplane::gears {
     template <typename T>
     struct SuccessTag {
         T value;
-        explicit SuccessTag(T&& v) : value(std::forward<T>(v)) {}
+        constexpr explicit SuccessTag(T v)
+            : value(std::move(v)) {
+        }
     };
 
     template <typename T>
-    SuccessTag<std::decay_t<T>> Ok(T&& v) {
+    constexpr SuccessTag<std::decay_t<T>> Ok(T&& v) {
         return SuccessTag<std::decay_t<T>>{std::forward<T>(v)};
     }
+
+    constexpr std::monostate Ok() {
+        return {};
+    }
+
 
     template <typename T, typename... Errors>
     class Outcome {
     public:
-        using value_type = T;
+        using value_type  = T;
         using error_types = std::variant<Errors...>;
 
         // Default constructor (requires T to be default constructible)
-        Outcome() requires std::default_initializable<T>
-            : value_(T{}) {}
+        Outcome() noexcept(std::is_nothrow_constructible_v<T>)
+            requires std::default_initializable<T>
+            : value_(T{}) {
+        }
 
-        // Implicit construction from value
-        template<typename U = std::remove_cv_t<T>>
-        constexpr  explicit(!std::is_convertible_v<U, T>) Outcome(T value)
-            : value_(std::move(value)) {}
+        // Implicit construction from value - ensure U is not an error type
+        template <typename U = std::remove_cv_t<T>>
+            requires std::constructible_from<T, U> &&
+                     (!OneOf<std::decay_t<U>, Errors...>) &&
+                     (!std::same_as<std::decay_t<U>, ErrorTag<std::decay_t<U>>>) &&
+                     (!std::same_as<std::decay_t<U>, SuccessTag<std::decay_t<U>>>)
+        constexpr explicit(!std::is_convertible_v<U, T>) Outcome(U&& value)
+            noexcept(std::is_nothrow_constructible_v<T, U>)
+            : value_(std::forward<U>(value)) {
+        }
 
         // Implicit construction from SuccessTag
-        template <typename U = std::remove_cv_t<T>>
-        // ReSharper disable once CppNonExplicitConvertingConstructor
+        template <typename U>
+            requires std::constructible_from<T, U>
         constexpr explicit(!std::is_convertible_v<U, T>) Outcome(SuccessTag<U>&& tag)
-            : value_(std::move(tag.value)) {}
+            noexcept(std::is_nothrow_constructible_v<T, U>)
+            : value_(std::move(tag.value)) {
+        }
 
         // Implicit construction from ErrorTag
         template <OneOf<Errors...> E>
-        constexpr explicit(!gears::OneOf<E, Errors...>) Outcome(ErrorTag<E>&& tag)
-            : value_(std::move(tag.error)) {}
+        constexpr explicit(false) Outcome(ErrorTag<E>&& tag)
+            noexcept(std::is_nothrow_move_constructible_v<E>)
+            : value_(std::move(tag.error)) {
+        }
 
-        // Direct error construction - more ergonomic
+        // Direct error construction
         template <OneOf<Errors...> E>
         static constexpr Outcome error(E&& e) {
             Outcome result;
@@ -70,7 +89,7 @@ namespace demiplane::gears {
         }
 
         // Success factory
-        static constexpr Outcome success(T&& value) {
+        static constexpr Outcome success(T&& value) noexcept(std::is_nothrow_constructible_v<T, T&&>) {
             return Outcome{std::forward<T>(value)};
         }
 
@@ -92,7 +111,7 @@ namespace demiplane::gears {
             return is_success();
         }
 
-        // Value accessors with better names
+        // Value accessors
         [[nodiscard]] constexpr const T& value() const& {
             if (!is_success()) {
                 throw std::bad_variant_access{};
@@ -114,7 +133,7 @@ namespace demiplane::gears {
             return std::move(std::get<T>(value_));
         }
 
-        // Operator * for dereferencing like a pointer
+        // Operator * for dereferencing
         [[nodiscard]] constexpr const T& operator*() const& {
             return value();
         }
@@ -124,7 +143,7 @@ namespace demiplane::gears {
         }
 
         [[nodiscard]] constexpr T&& operator*() && {
-            return std::move(value());
+            return std::move(*this).value();
         }
 
         // Operator -> for member access
@@ -136,20 +155,15 @@ namespace demiplane::gears {
             return &value();
         }
 
+        // value_or
         template <class U = T>
         constexpr T value_or(U&& default_value) const& {
-            if (is_success()) {
-                return std::get<T>(value_);
-            }
-            return static_cast<T>(std::forward<U>(default_value));
+            return is_success() ? std::get<T>(value_) : static_cast<T>(std::forward<U>(default_value));
         }
 
         template <class U = T>
         constexpr T value_or(U&& default_value) && {
-            if (is_success()) {
-                return std::move(std::get<T>(value_));
-            }
-            return static_cast<T>(std::forward<U>(default_value));
+            return is_success() ? std::move(std::get<T>(value_)) : static_cast<T>(std::forward<U>(default_value));
         }
 
         // Get specific error type
@@ -168,54 +182,135 @@ namespace demiplane::gears {
             return std::move(std::get<E>(value_));
         }
 
-        // Get error as variant
-        [[nodiscard]] constexpr const error_types& error_variant() const& {
-            if (is_success()) {
-                throw std::bad_variant_access{};
-            }
-            return std::get<error_types>(
-                reinterpret_cast<const std::variant<T, error_types>&>(value_)
-            );
-        }
-
-        // Monadic operations
+        // Monadic operations - and_then
         template <typename F>
-        constexpr auto and_then(F&& f) & -> decltype(f(value())) {
+            requires std::invocable<F, T&>
+        constexpr auto and_then(F&& f) & -> std::invoke_result_t<F, T&> {
+            using Result = std::invoke_result_t<F, T&>;
             if (is_success()) {
-                return f(value());
+                return std::invoke(std::forward<F>(f), value());
             }
-            return *this;
-        }
-
-        template <typename F>
-        constexpr auto and_then(F&& f) && -> decltype(f(std::move(value()))) {
-            if (is_success()) {
-                return f(std::move(value()));
-            }
-            return std::move(*this);
-        }
-
-        template <typename F>
-        constexpr auto or_else(F&& f) & {
-            if (!is_success()) {
-                return f();
-            }
-            return *this;
-        }
-
-        template <typename F>
-        constexpr auto transform(F&& f) & {
-            using U = decltype(f(value()));
-            if (is_success()) {
-                return Outcome<U, Errors...>{f(value())};
-            }
-            // Need to convert errors
-            Outcome<U, Errors...> result;
-            std::visit([&result](auto&& err) {
-                if constexpr (!std::is_same_v<std::decay_t<decltype(err)>, T>) {
-                    result = ErrorTag{std::forward<decltype(err)>(err)};
+            // Propagate error to Result type
+            Result result;
+            std::visit([&result]<typename ErrT>(ErrT&& err) {
+                if constexpr (!std::same_as<std::decay_t<ErrT>, T>) {
+                    result = ErrorTag{std::forward<ErrT>(err)};
                 }
             }, value_);
+            return result;
+        }
+
+        template <typename F>
+            requires std::invocable<F, const T&>
+        constexpr auto and_then(F&& f) const& -> std::invoke_result_t<F, const T&> {
+            using Result = std::invoke_result_t<F, const T&>;
+            if (is_success()) {
+                return std::invoke(std::forward<F>(f), value());
+            }
+            Result result;
+            std::visit([&result]<typename ErrT>(const ErrT& err) {
+                if constexpr (!std::same_as<std::decay_t<ErrT>, T>) {
+                    result = ErrorTag{err};
+                }
+            }, value_);
+            return result;
+        }
+
+        template <typename F>
+            requires std::invocable<F, T&&>
+        constexpr auto and_then(F&& f) && -> std::invoke_result_t<F, T&&> {
+            using Result = std::invoke_result_t<F, T&&>;
+            if (is_success()) {
+                return std::invoke(std::forward<F>(f), std::move(*this).value());
+            }
+            Result result;
+            std::visit([&result]<typename ErrT>(ErrT&& err) {
+                if constexpr (!std::same_as<std::decay_t<ErrT>, T>) {
+                    result = ErrorTag{std::forward<ErrT>(err)};
+                }
+            }, std::move(value_));
+            return result;
+        }
+
+        // or_else - execute function if error
+        template <typename F>
+            requires std::invocable<F>
+        constexpr auto or_else(F&& f) & -> std::invoke_result_t<F> {
+            if (is_error()) {
+                return std::invoke(std::forward<F>(f));
+            }
+            // Need to convert success to result type
+            using Result = std::invoke_result_t<F>;
+            return Result{value()};
+        }
+
+        template <typename F>
+            requires std::invocable<F>
+        constexpr auto or_else(F&& f) const& -> std::invoke_result_t<F> {
+            if (is_error()) {
+                return std::invoke(std::forward<F>(f));
+            }
+            using Result = std::invoke_result_t<F>;
+            return Result{value()};
+        }
+
+        template <typename F>
+            requires std::invocable<F>
+        constexpr auto or_else(F&& f) && -> std::invoke_result_t<F> {
+            if (is_error()) {
+                return std::invoke(std::forward<F>(f));
+            }
+            using Result = std::invoke_result_t<F>;
+            return Result{std::move(*this).value()};
+        }
+
+        // transform - map over success value
+        template <typename F>
+            requires std::invocable<F, T&>
+        constexpr auto transform(F&& f) & {
+            using U = std::invoke_result_t<F, T&>;
+            if (is_success()) {
+                return Outcome<U, Errors...>{std::invoke(std::forward<F>(f), value())};
+            }
+            // Propagate errors
+            Outcome<U, Errors...> result;
+            std::visit([&result]<typename ErrT>(ErrT&& err) {
+                if constexpr (!std::same_as<std::decay_t<ErrT>, T>) {
+                    result = ErrorTag{std::forward<ErrT>(err)};
+                }
+            }, value_);
+            return result;
+        }
+
+        template <typename F>
+            requires std::invocable<F, const T&>
+        constexpr auto transform(F&& f) const& {
+            using U = std::invoke_result_t<F, const T&>;
+            if (is_success()) {
+                return Outcome<U, Errors...>{std::invoke(std::forward<F>(f), value())};
+            }
+            Outcome<U, Errors...> result;
+            std::visit([&result]<typename ErrT>(const ErrT& err) {
+                if constexpr (!std::same_as<std::decay_t<ErrT>, T>) {
+                    result = ErrorTag{err};
+                }
+            }, value_);
+            return result;
+        }
+
+        template <typename F>
+            requires std::invocable<F, T&&>
+        constexpr auto transform(F&& f) && {
+            using U = std::invoke_result_t<F, T&&>;
+            if (is_success()) {
+                return Outcome<U, Errors...>{std::invoke(std::forward<F>(f), std::move(*this).value())};
+            }
+            Outcome<U, Errors...> result;
+            std::visit([&result]<typename ErrT>(ErrT&& err) {
+                if constexpr (!std::same_as<std::decay_t<ErrT>, T>) {
+                    result = ErrorTag{std::forward<ErrT>(err)};
+                }
+            }, std::move(value_));
             return result;
         }
 
@@ -240,17 +335,245 @@ namespace demiplane::gears {
     };
 
 
+    // Void specialization
+    template <typename... Errors>
+    class Outcome<void, Errors...> {
+    public:
+        using value_type  = void;
+        using error_types = std::variant<Errors...>;
 
-    // Convenience factory functions
-    template <typename T, typename... Errors>
-    constexpr auto success(T&& value) -> Outcome<std::decay_t<T>, Errors...> {
-        return Outcome<std::decay_t<T>, Errors...>::success(std::forward<T>(value));
+        // Default constructor - represents success
+        constexpr Outcome() noexcept
+            : value_(std::monostate{}) {
+        }
+
+        // Construct from monostate (success)
+        constexpr explicit(false) Outcome(std::monostate) noexcept
+            : value_(std::monostate{}) {
+        }
+
+        // Implicit construction from ErrorTag
+        template <OneOf<Errors...> E>
+        constexpr explicit(false) Outcome(ErrorTag<E>&& tag)
+            noexcept(std::is_nothrow_move_constructible_v<E>)
+            : value_(std::move(tag.error)) {
+        }
+
+        // Direct error construction
+        template <OneOf<Errors...> E>
+        static constexpr Outcome error(E&& e) {
+            Outcome result;
+            result.value_ = std::forward<E>(e);
+            return result;
+        }
+
+        // Success factory
+        static constexpr Outcome success() noexcept {
+            return Outcome{};
+        }
+
+        [[nodiscard]] constexpr bool is_success() const noexcept {
+            return std::holds_alternative<std::monostate>(value_);
+        }
+
+        [[nodiscard]] constexpr bool is_error() const noexcept {
+            return !is_success();
+        }
+
+        template <OneOf<Errors...> E>
+        [[nodiscard]] constexpr bool holds_error() const noexcept {
+            return std::holds_alternative<E>(value_);
+        }
+
+        // Operator bool for if statements
+        [[nodiscard]] constexpr explicit operator bool() const noexcept {
+            return is_success();
+        }
+
+        // Assert success (for void, we can't return a value)
+        constexpr void ensure_success() const {
+            if (!is_success()) {
+                throw std::bad_variant_access{};
+            }
+        }
+
+        // Get specific error type
+        template <OneOf<Errors...> E>
+        [[nodiscard]] constexpr const E& error() const& {
+            return std::get<E>(value_);
+        }
+
+        template <OneOf<Errors...> E>
+        [[nodiscard]] constexpr E& error() & {
+            return std::get<E>(value_);
+        }
+
+        template <OneOf<Errors...> E>
+        [[nodiscard]] constexpr E&& error() && {
+            return std::move(std::get<E>(value_));
+        }
+
+        // Monadic operations - and_then
+        template <typename F>
+            requires std::invocable<F>
+        constexpr auto and_then(F&& f) const& -> std::invoke_result_t<F> {
+            using Result = std::invoke_result_t<F>;
+            if (is_success()) {
+                return std::invoke(std::forward<F>(f));
+            }
+            // Propagate error
+            Result result;
+            std::visit([&result]<typename ErrT>(const ErrT& err) {
+                if constexpr (!std::same_as<std::decay_t<ErrT>, std::monostate>) {
+                    result = ErrorTag{err};
+                }
+            }, value_);
+            return result;
+        }
+
+        template <typename F>
+            requires std::invocable<F>
+        constexpr auto and_then(F&& f) && -> std::invoke_result_t<F> {
+            using Result = std::invoke_result_t<F>;
+            if (is_success()) {
+                return std::invoke(std::forward<F>(f));
+            }
+            Result result;
+            std::visit([&result]<typename ErrT>(ErrT&& err) {
+                if constexpr (!std::same_as<std::decay_t<ErrT>, std::monostate>) {
+                    result = ErrorTag{std::forward<ErrT>(err)};
+                }
+            }, std::move(value_));
+            return result;
+        }
+
+        // or_else
+        template <typename F>
+            requires std::invocable<F>
+        constexpr auto or_else(F&& f) const& -> std::invoke_result_t<F> {
+            if (is_error()) {
+                return std::invoke(std::forward<F>(f));
+            }
+            using Result = std::invoke_result_t<F>;
+            return Result{};
+        }
+
+        template <typename F>
+            requires std::invocable<F>
+        constexpr auto or_else(F&& f) && -> std::invoke_result_t<F> {
+            if (is_error()) {
+                return std::invoke(std::forward<F>(f));
+            }
+            using Result = std::invoke_result_t<F>;
+            return Result{};
+        }
+
+        // transform - converts void to non-void outcome
+        template <typename F>
+            requires std::invocable<F>
+        constexpr auto transform(F&& f) const& {
+            using U = std::invoke_result_t<F>;
+            if (is_success()) {
+                return Outcome<U, Errors...>{std::invoke(std::forward<F>(f))};
+            }
+            // Propagate errors
+            Outcome<U, Errors...> result;
+            std::visit([&result]<typename ErrT>(const ErrT& err) {
+                if constexpr (!std::same_as<std::decay_t<ErrT>, std::monostate>) {
+                    result = ErrorTag{err};
+                }
+            }, value_);
+            return result;
+        }
+
+        template <typename F>
+            requires std::invocable<F>
+        constexpr auto transform(F&& f) && {
+            using U = std::invoke_result_t<F>;
+            if (is_success()) {
+                return Outcome<U, Errors...>{std::invoke(std::forward<F>(f))};
+            }
+            Outcome<U, Errors...> result;
+            std::visit([&result]<typename ErrT>(ErrT&& err) {
+                if constexpr (!std::same_as<std::decay_t<ErrT>, std::monostate>) {
+                    result = ErrorTag{std::forward<ErrT>(err)};
+                }
+            }, std::move(value_));
+            return result;
+        }
+
+        // Visit pattern
+        template <typename... Fs>
+        constexpr decltype(auto) visit(Fs&&... fs) const& {
+            return std::visit(overloaded{std::forward<Fs>(fs)...}, value_);
+        }
+
+        template <typename... Fs>
+        constexpr decltype(auto) visit(Fs&&... fs) && {
+            return std::visit(overloaded{std::forward<Fs>(fs)...}, std::move(value_));
+        }
+
+    private:
+        std::variant<std::monostate, Errors...> value_;
+    };
+
+    // Utility to combine multiple outcomes
+    // Returns Outcome<std::tuple<Values...>, Errors...> or Outcome<void, Errors...>
+    template <typename T, typename... Errors, typename... Rest>
+    constexpr auto combine_outcomes(const Outcome<T, Errors...>& first, const Rest&... rest) {
+        // Check if all are successful
+        if (!first.is_success() || (!rest.is_success() || ...)) {
+            // Return first error found
+            if (!first.is_success()) {
+                if constexpr (std::same_as<T, void>) {
+                    return first;
+                } else {
+                    Outcome<void, Errors...> result;
+                    first.visit([&result]<typename ErrT>(const ErrT& err) {
+                        if constexpr (!std::same_as<std::decay_t<ErrT>, T>) {
+                            result = ErrorTag{err};
+                        }
+                    });
+                    return result;
+                }
+            }
+
+            // Check rest for first error
+            Outcome<void, Errors...> result;
+            auto check_error = [&result]<typename OutcomeT>(const OutcomeT& outcome) {
+                if (!outcome.is_success() && result.is_success()) {
+                    outcome.visit([&result]<typename ErrT>(const ErrT& err) {
+                        using OutcomeType = std::decay_t<OutcomeT>;
+                        using ValueType = OutcomeType::value_type;
+                        if constexpr (!std::same_as<std::decay_t<ErrT>, ValueType> &&
+                                      !std::same_as<std::decay_t<ErrT>, std::monostate>) {
+                            result = ErrorTag{err};
+                        }
+                    });
+                }
+            };
+            (check_error(rest), ...);
+            return result;
+        }
+
+        // All successful - combine values
+        if constexpr (std::same_as<T, void> && (std::same_as<typename std::decay_t<Rest>::value_type, void> && ...)) {
+            // All void outcomes - return void success
+            return Outcome<void, Errors...>{};
+        } else if constexpr (std::same_as<T, void>) {
+            // Mixed void and non-void - return tuple of non-void values
+            return Outcome<std::tuple<typename std::decay_t<Rest>::value_type...>, Errors...>{
+                std::make_tuple(rest.value()...)
+            };
+        } else if constexpr ((std::same_as<typename std::decay_t<Rest>::value_type, void> && ...)) {
+            // First is non-void, rest are void
+            return Outcome<T, Errors...>{first.value()};
+        } else {
+            // All non-void - return tuple
+            return Outcome<std::tuple<T, typename std::decay_t<Rest>::value_type...>, Errors...>{
+                std::make_tuple(first.value(), rest.value()...)
+            };
+        }
     }
 
-    template <typename... Errors, typename E>
-    requires OneOfDecayed<E, Errors...>
-    constexpr auto failure(E&& error) -> Outcome<void, Errors...> {
-        return Outcome<void, Errors...>::error(std::forward<E>(error));
-    }
-
-} // namespace demiplane::gears
+}  // namespace demiplane::gears

--- a/common/gears/result/include/gears_outcome.hpp
+++ b/common/gears/result/include/gears_outcome.hpp
@@ -1,0 +1,256 @@
+#pragma once
+
+#include <variant>
+#include <type_traits>
+#include "gears_concepts.hpp"
+#include "gears_templates.hpp"
+namespace demiplane::gears {
+
+    // Forward declaration
+    template <typename T, typename... Errors>
+    class Outcome;
+
+    // Error wrapper for implicit construction
+    template <typename E>
+    struct ErrorTag {
+        E error;
+        explicit ErrorTag(E&& e) : error(std::forward<E>(e)) {}
+    };
+
+    // Helper to deduce error type
+    template <typename E>
+    ErrorTag<std::decay_t<E>> Err(E&& e) {
+        return ErrorTag<std::decay_t<E>>{std::forward<E>(e)};
+    }
+
+    // Success wrapper for implicit construction
+    template <typename T>
+    struct SuccessTag {
+        T value;
+        explicit SuccessTag(T&& v) : value(std::forward<T>(v)) {}
+    };
+
+    template <typename T>
+    SuccessTag<std::decay_t<T>> Ok(T&& v) {
+        return SuccessTag<std::decay_t<T>>{std::forward<T>(v)};
+    }
+
+    template <typename T, typename... Errors>
+    class Outcome {
+    public:
+        using value_type = T;
+        using error_types = std::variant<Errors...>;
+
+        // Default constructor (requires T to be default constructible)
+        Outcome() requires std::default_initializable<T>
+            : value_(T{}) {}
+
+        // Implicit construction from value
+        template<typename U = std::remove_cv_t<T>>
+        constexpr  explicit(!std::is_convertible_v<U, T>) Outcome(T value)
+            : value_(std::move(value)) {}
+
+        // Implicit construction from SuccessTag
+        template <typename U = std::remove_cv_t<T>>
+        // ReSharper disable once CppNonExplicitConvertingConstructor
+        constexpr explicit(!std::is_convertible_v<U, T>) Outcome(SuccessTag<U>&& tag)
+            : value_(std::move(tag.value)) {}
+
+        // Implicit construction from ErrorTag
+        template <OneOf<Errors...> E>
+        constexpr explicit(!gears::OneOf<E, Errors...>) Outcome(ErrorTag<E>&& tag)
+            : value_(std::move(tag.error)) {}
+
+        // Direct error construction - more ergonomic
+        template <OneOf<Errors...> E>
+        static constexpr Outcome error(E&& e) {
+            Outcome result;
+            result.value_ = std::forward<E>(e);
+            return result;
+        }
+
+        // Success factory
+        static constexpr Outcome success(T&& value) {
+            return Outcome{std::forward<T>(value)};
+        }
+
+        [[nodiscard]] constexpr bool is_success() const noexcept {
+            return std::holds_alternative<T>(value_);
+        }
+
+        [[nodiscard]] constexpr bool is_error() const noexcept {
+            return !is_success();
+        }
+
+        template <OneOf<Errors...> E>
+        [[nodiscard]] constexpr bool holds_error() const noexcept {
+            return std::holds_alternative<E>(value_);
+        }
+
+        // Operator bool for if statements
+        [[nodiscard]] constexpr explicit operator bool() const noexcept {
+            return is_success();
+        }
+
+        // Value accessors with better names
+        [[nodiscard]] constexpr const T& value() const& {
+            if (!is_success()) {
+                throw std::bad_variant_access{};
+            }
+            return std::get<T>(value_);
+        }
+
+        [[nodiscard]] constexpr T& value() & {
+            if (!is_success()) {
+                throw std::bad_variant_access{};
+            }
+            return std::get<T>(value_);
+        }
+
+        [[nodiscard]] constexpr T&& value() && {
+            if (!is_success()) {
+                throw std::bad_variant_access{};
+            }
+            return std::move(std::get<T>(value_));
+        }
+
+        // Operator * for dereferencing like a pointer
+        [[nodiscard]] constexpr const T& operator*() const& {
+            return value();
+        }
+
+        [[nodiscard]] constexpr T& operator*() & {
+            return value();
+        }
+
+        [[nodiscard]] constexpr T&& operator*() && {
+            return std::move(value());
+        }
+
+        // Operator -> for member access
+        [[nodiscard]] constexpr const T* operator->() const {
+            return &value();
+        }
+
+        [[nodiscard]] constexpr T* operator->() {
+            return &value();
+        }
+
+        template <class U = T>
+        constexpr T value_or(U&& default_value) const& {
+            if (is_success()) {
+                return std::get<T>(value_);
+            }
+            return static_cast<T>(std::forward<U>(default_value));
+        }
+
+        template <class U = T>
+        constexpr T value_or(U&& default_value) && {
+            if (is_success()) {
+                return std::move(std::get<T>(value_));
+            }
+            return static_cast<T>(std::forward<U>(default_value));
+        }
+
+        // Get specific error type
+        template <OneOf<Errors...> E>
+        [[nodiscard]] constexpr const E& error() const& {
+            return std::get<E>(value_);
+        }
+
+        template <OneOf<Errors...> E>
+        [[nodiscard]] constexpr E& error() & {
+            return std::get<E>(value_);
+        }
+
+        template <OneOf<Errors...> E>
+        [[nodiscard]] constexpr E&& error() && {
+            return std::move(std::get<E>(value_));
+        }
+
+        // Get error as variant
+        [[nodiscard]] constexpr const error_types& error_variant() const& {
+            if (is_success()) {
+                throw std::bad_variant_access{};
+            }
+            return std::get<error_types>(
+                reinterpret_cast<const std::variant<T, error_types>&>(value_)
+            );
+        }
+
+        // Monadic operations
+        template <typename F>
+        constexpr auto and_then(F&& f) & -> decltype(f(value())) {
+            if (is_success()) {
+                return f(value());
+            }
+            return *this;
+        }
+
+        template <typename F>
+        constexpr auto and_then(F&& f) && -> decltype(f(std::move(value()))) {
+            if (is_success()) {
+                return f(std::move(value()));
+            }
+            return std::move(*this);
+        }
+
+        template <typename F>
+        constexpr auto or_else(F&& f) & {
+            if (!is_success()) {
+                return f();
+            }
+            return *this;
+        }
+
+        template <typename F>
+        constexpr auto transform(F&& f) & {
+            using U = decltype(f(value()));
+            if (is_success()) {
+                return Outcome<U, Errors...>{f(value())};
+            }
+            // Need to convert errors
+            Outcome<U, Errors...> result;
+            std::visit([&result](auto&& err) {
+                if constexpr (!std::is_same_v<std::decay_t<decltype(err)>, T>) {
+                    result = ErrorTag{std::forward<decltype(err)>(err)};
+                }
+            }, value_);
+            return result;
+        }
+
+        // Visit pattern for exhaustive matching
+        template <typename... Fs>
+        constexpr decltype(auto) visit(Fs&&... fs) & {
+            return std::visit(overloaded{std::forward<Fs>(fs)...}, value_);
+        }
+
+        template <typename... Fs>
+        constexpr decltype(auto) visit(Fs&&... fs) const& {
+            return std::visit(overloaded{std::forward<Fs>(fs)...}, value_);
+        }
+
+        template <typename... Fs>
+        constexpr decltype(auto) visit(Fs&&... fs) && {
+            return std::visit(overloaded{std::forward<Fs>(fs)...}, std::move(value_));
+        }
+
+    private:
+        std::variant<T, Errors...> value_;
+    };
+
+
+
+    // Convenience factory functions
+    template <typename T, typename... Errors>
+    constexpr auto success(T&& value) -> Outcome<std::decay_t<T>, Errors...> {
+        return Outcome<std::decay_t<T>, Errors...>::success(std::forward<T>(value));
+    }
+
+    template <typename... Errors, typename E>
+    requires OneOfDecayed<E, Errors...>
+    constexpr auto failure(E&& error) -> Outcome<void, Errors...> {
+        return Outcome<void, Errors...>::error(std::forward<E>(error));
+    }
+
+} // namespace demiplane::gears

--- a/tests/codesandbox/CMakeLists.txt
+++ b/tests/codesandbox/CMakeLists.txt
@@ -3,6 +3,5 @@ add_executable(${PROJECT_NAME}.Tests.Sandbox
 )
 target_link_libraries(${PROJECT_NAME}.Tests.Sandbox
         PRIVATE
-        Demiplane.Component.Database.Query.Compiler
-        Demiplane.Component.Database.Dialect.PostgreSQL
+        Demiplane::Common::Gears
 )

--- a/tests/codesandbox/CMakeLists.txt
+++ b/tests/codesandbox/CMakeLists.txt
@@ -3,5 +3,4 @@ add_executable(${PROJECT_NAME}.Tests.Sandbox
 )
 target_link_libraries(${PROJECT_NAME}.Tests.Sandbox
         PRIVATE
-        Demiplane::Common::Gears
 )

--- a/tests/codesandbox/main.cpp
+++ b/tests/codesandbox/main.cpp
@@ -1,35 +1,3 @@
-#include <cstdint>
-#include <expected>
-#include <iostream>
-
-#include <gears_outcome.hpp>
-enum ErrorType : std::uint8_t {
-    ErrorType_None,
-    ErrorType_Unknown,
-    ErrorType_Invalid,
-    ErrorType_Timeout,
-    ErrorType_Busy
-};
-
-enum ErrorTypeOut : std::uint8_t { OutOfMemory, OutOfResources, OutOfCapacity };
-using namespace demiplane::gears;
-Outcome<void, ErrorType, ErrorTypeOut> test() {
-    Outcome<void, ErrorType, ErrorTypeOut> out;
-    return Ok();
-}
-Outcome<int, ErrorType, ErrorTypeOut> test2() {
-    return Ok(2);
-    return Err(ErrorType_Busy);
-}
-
-std::expected<int, int> g() {
-    return 1;
-}
-
- int main() {
-    auto res = test2();
-    std::cout << res.holds_error<ErrorType>() << std::endl;
-    std::cout << res.holds_error<ErrorTypeOut>() << std::endl;
-    std::cout << res.error<ErrorType>() << std::endl;
+int main() {
 
 }

--- a/tests/codesandbox/main.cpp
+++ b/tests/codesandbox/main.cpp
@@ -1,5 +1,6 @@
 #include <cstdint>
 #include <expected>
+#include <iostream>
 
 #include <gears_outcome.hpp>
 enum ErrorType : std::uint8_t {
@@ -12,7 +13,12 @@ enum ErrorType : std::uint8_t {
 
 enum ErrorTypeOut : std::uint8_t { OutOfMemory, OutOfResources, OutOfCapacity };
 using namespace demiplane::gears;
-Outcome<int, ErrorType, ErrorTypeOut> test() {
+Outcome<void, ErrorType, ErrorTypeOut> test() {
+    Outcome<void, ErrorType, ErrorTypeOut> out;
+    return Ok();
+}
+Outcome<int, ErrorType, ErrorTypeOut> test2() {
+    return Ok(2);
     return Err(ErrorType_Busy);
 }
 
@@ -21,6 +27,9 @@ std::expected<int, int> g() {
 }
 
  int main() {
-    test();
+    auto res = test2();
+    std::cout << res.holds_error<ErrorType>() << std::endl;
+    std::cout << res.holds_error<ErrorTypeOut>() << std::endl;
+    std::cout << res.error<ErrorType>() << std::endl;
 
 }

--- a/tests/codesandbox/main.cpp
+++ b/tests/codesandbox/main.cpp
@@ -1,56 +1,26 @@
-#include <chrono>
-#include <demiplane/chrono>
-#include <iostream>
-#include <thread>
+#include <cstdint>
+#include <expected>
 
-using namespace std::chrono_literals;
+#include <gears_outcome.hpp>
+enum ErrorType : std::uint8_t {
+    ErrorType_None,
+    ErrorType_Unknown,
+    ErrorType_Invalid,
+    ErrorType_Timeout,
+    ErrorType_Busy
+};
 
-int find_prims(const int a) {
-    std::cout << "executor: " << std::this_thread::get_id() << std::endl;
-    demiplane::chrono::sleep_for(100ms);
-    std::cout << "find prims " << a << std::endl;
-    demiplane::chrono::sleep_for(200ms);
-    std::cout << "find prims " << a << std::endl;
-    demiplane::chrono::sleep_for(500ms);
-    std::cout << "find prims " << a << std::endl;
-    demiplane::chrono::sleep_for(1000ms);
-    std::cout << "find prims " << a << std::endl;
-    return a;
+enum ErrorTypeOut : std::uint8_t { OutOfMemory, OutOfResources, OutOfCapacity };
+using namespace demiplane::gears;
+Outcome<int, ErrorType, ErrorTypeOut> test() {
+    return Err(ErrorType_Busy);
 }
 
-void heavy_work(const std::shared_ptr<demiplane::chrono::CancellationToken>& token) {
-    for (int i = 0; !token->stop_requested(); ++i) {
-        demiplane::chrono::sleep_for(10ms);
-        std::cout << "heavy work " << i << std::endl;
-    }
+std::expected<int, int> g() {
+    return 1;
 }
 
-int main() {
-    auto token = std::make_shared<demiplane::chrono::CancellationToken>();
-    constexpr demiplane::multithread::ThreadPoolConfig cfg;
-    std::cout << "main: " << std::this_thread::get_id() << std::endl;
-    demiplane::chrono::Timer t(cfg);
-    std::jthread th{[&token] {
-        demiplane::chrono::sleep_for(100ms);
-        token->cancel();
-        std::cout << "cancel from thread1 " << std::this_thread::get_id() << std::endl;
-    }};
-    // 1. Polite vanish: callable accepts token
-    const std::future<void> future_ok = t.execute_polite_vanish(50ms, &heavy_work, token);
-    //
+ int main() {
+    test();
 
-
-    future_ok.wait();
-    token->renew();
-    std::jthread th2{[&token] {
-        demiplane::chrono::sleep_for(900ms);
-        token->cancel();
-        std::cout << "cancel from thread2 " << std::this_thread::get_id() << std::endl;
-    }};
-    // 2. Violent kill: legacy callable
-    const auto future_legacy = t.execute_violent_kill(3000ms, token, &find_prims, 123456789);
-    // cancel from outside
-    future_legacy.wait();
-
-    return 0;
 }

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -73,5 +73,18 @@ target_link_libraries(${UNIT_TESTING_TARGET}.Algorithms
 )
 ##############################################################################
 
+##############################################################################
+# Test Gears Result (Outcome)
+##############################################################################
+add_unit_test(${UNIT_TESTING_TARGET}.Gears.Result
+        gears/test_outcome.cpp
+)
+target_link_libraries(${UNIT_TESTING_TARGET}.Gears.Result
+        PRIVATE
+        Demiplane::Common::Gears
+        ${TEST_LIBS}
+)
+##############################################################################
+
 
 

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -76,10 +76,10 @@ target_link_libraries(${UNIT_TESTING_TARGET}.Algorithms
 ##############################################################################
 # Test Gears Result (Outcome)
 ##############################################################################
-add_unit_test(${UNIT_TESTING_TARGET}.Gears.Result
+add_unit_test(${UNIT_TESTING_TARGET}.Gears.Result.Outcome
         gears/test_outcome.cpp
 )
-target_link_libraries(${UNIT_TESTING_TARGET}.Gears.Result
+target_link_libraries(${UNIT_TESTING_TARGET}.Gears.Result.Outcome
         PRIVATE
         Demiplane::Common::Gears
         ${TEST_LIBS}

--- a/tests/unit_tests/gears/test_outcome.cpp
+++ b/tests/unit_tests/gears/test_outcome.cpp
@@ -1,0 +1,539 @@
+#include <string>
+#include <vector>
+
+#include <gears_outcome.hpp>
+
+#include "gears_utils.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace demiplane::gears;
+
+// Test error types
+enum class IOError {
+    FileNotFound,
+    PermissionDenied,
+    DiskFull
+};
+
+enum class NetworkError {
+    Timeout,
+    ConnectionRefused,
+    InvalidResponse
+};
+
+struct ParseError {
+    std::string message;
+    int line_number;
+
+    bool operator==(const ParseError& other) const {
+        return message == other.message && line_number == other.line_number;
+    }
+};
+
+// ============================================================================
+// Basic Construction Tests
+// ============================================================================
+
+TEST(OutcomeTest, DefaultConstructionWithDefaultConstructibleType) {
+    Outcome<int, IOError> result;
+    EXPECT_TRUE(result.is_success());
+    EXPECT_FALSE(result.is_error());
+    EXPECT_EQ(result.value(), 0);
+}
+
+TEST(OutcomeTest, ConstructionFromValue) {
+    Outcome<int, IOError> result(42);
+    EXPECT_TRUE(result.is_success());
+    EXPECT_EQ(result.value(), 42);
+}
+
+TEST(OutcomeTest, ConstructionFromSuccessTag) {
+    Outcome<int, IOError> result = Ok(42);
+    EXPECT_TRUE(result.is_success());
+    EXPECT_EQ(result.value(), 42);
+}
+
+TEST(OutcomeTest, ConstructionFromErrorTag) {
+    Outcome<int, IOError> result = Err(IOError::FileNotFound);
+    EXPECT_TRUE(result.is_error());
+    EXPECT_FALSE(result.is_success());
+    EXPECT_TRUE(result.holds_error<IOError>());
+    EXPECT_EQ(result.error<IOError>(), IOError::FileNotFound);
+}
+
+TEST(OutcomeTest, ConstructionWithMultipleErrorTypes) {
+    Outcome<std::string, IOError, NetworkError> result1 = Err(IOError::DiskFull);
+    EXPECT_TRUE(result1.holds_error<IOError>());
+    EXPECT_FALSE(result1.holds_error<NetworkError>());
+
+    Outcome<std::string, IOError, NetworkError> result2 = Err(NetworkError::Timeout);
+    EXPECT_TRUE(result2.holds_error<NetworkError>());
+    EXPECT_FALSE(result2.holds_error<IOError>());
+}
+
+TEST(OutcomeTest, SuccessFactoryMethod) {
+    auto result = Outcome<int, IOError>::success(100);
+    EXPECT_TRUE(result.is_success());
+    EXPECT_EQ(result.value(), 100);
+}
+
+TEST(OutcomeTest, ErrorFactoryMethod) {
+    auto result = Outcome<int, IOError>::error(IOError::PermissionDenied);
+    EXPECT_TRUE(result.is_error());
+    EXPECT_EQ(result.error<IOError>(), IOError::PermissionDenied);
+}
+
+TEST(OutcomeTest, ConstructionWithComplexType) {
+    ParseError err{"Invalid syntax", 42};
+    Err(std::move(err));
+    Outcome<std::string, ParseError> result;
+    EXPECT_TRUE(result.is_error());
+    EXPECT_EQ(result.error<ParseError>(), err);
+}
+
+// ============================================================================
+// Operator bool and Value Access Tests
+// ============================================================================
+
+TEST(OutcomeTest, OperatorBoolSuccess) {
+    Outcome<int, IOError> result(42);
+    if (result) {
+        EXPECT_EQ(*result, 42);
+    } else {
+        FAIL() << "Expected success";
+    }
+}
+
+TEST(OutcomeTest, OperatorBoolError) {
+    Outcome<int, IOError> result = Err(IOError::FileNotFound);
+    if (!result) {
+        EXPECT_EQ(result.error<IOError>(), IOError::FileNotFound);
+    } else {
+        FAIL() << "Expected error";
+    }
+}
+
+TEST(OutcomeTest, ValueAccessThrowsOnError) {
+    Outcome<int, IOError> result = Err(IOError::FileNotFound);
+    EXPECT_THROW(unused_value(result.value()), std::bad_variant_access);
+}
+
+TEST(OutcomeTest, OperatorDereference) {
+    Outcome<int, IOError> result(42);
+    EXPECT_EQ(*result, 42);
+    *result = 100;
+    EXPECT_EQ(*result, 100);
+}
+
+TEST(OutcomeTest, OperatorArrow) {
+    Outcome<std::string, IOError> result("hello");
+    EXPECT_EQ(result->size(), 5);
+    EXPECT_EQ(result->length(), 5);
+}
+
+TEST(OutcomeTest, ValueOr) {
+    Outcome<int, IOError> success(42);
+    EXPECT_EQ(success.value_or(100), 42);
+
+    Outcome<int, IOError> error = Err(IOError::FileNotFound);
+    EXPECT_EQ(error.value_or(100), 100);
+}
+
+TEST(OutcomeTest, MoveSemantics) {
+    Outcome<std::string, IOError> result("hello world");
+    std::string value = std::move(result).value();
+    EXPECT_EQ(value, "hello world");
+}
+
+// ============================================================================
+// Monadic Operations - and_then
+// ============================================================================
+
+TEST(OutcomeTest, AndThenSuccess) {
+    Outcome<int, IOError> result(5);
+    auto doubled = result.and_then([](int x) {
+        return Outcome<int, IOError>(x * 2);
+    });
+    EXPECT_TRUE(doubled.is_success());
+    EXPECT_EQ(doubled.value(), 10);
+}
+
+TEST(OutcomeTest, AndThenError) {
+    Outcome<int, IOError> result = Err(IOError::FileNotFound);
+    auto doubled = result.and_then([](int x) {
+        return Outcome<int, IOError>(x * 2);
+    });
+    EXPECT_TRUE(doubled.is_error());
+    EXPECT_EQ(doubled.error<IOError>(), IOError::FileNotFound);
+}
+
+TEST(OutcomeTest, AndThenChaining) {
+    auto result = Outcome<int, IOError>(10)
+                      .and_then([](int x) { return Outcome<int, IOError>(x + 5); })
+                      .and_then([](int x) { return Outcome<int, IOError>(x * 2); });
+    EXPECT_TRUE(result.is_success());
+    EXPECT_EQ(result.value(), 30);
+}
+
+TEST(OutcomeTest, AndThenErrorPropagation) {
+    auto result = Outcome<int, IOError>(10)
+                      .and_then([]([[maybe_unused]] int x) { return Outcome<int, IOError>::error(IOError::DiskFull); })
+                      .and_then([](int x) { return Outcome<int, IOError>(x * 2); });
+    EXPECT_TRUE(result.is_error());
+    EXPECT_EQ(result.error<IOError>(), IOError::DiskFull);
+}
+
+// ============================================================================
+// Monadic Operations - or_else
+// ============================================================================
+
+TEST(OutcomeTest, OrElseSuccess) {
+    Outcome<int, IOError> result(42);
+    auto recovered = result.or_else([]() {
+        return Outcome<int, IOError>(0);
+    });
+    EXPECT_TRUE(recovered.is_success());
+    EXPECT_EQ(recovered.value(), 42);
+}
+
+TEST(OutcomeTest, OrElseError) {
+    Outcome<int, IOError> result = Err(IOError::FileNotFound);
+    auto recovered = result.or_else([]() {
+        return Outcome<int, IOError>(100);
+    });
+    EXPECT_TRUE(recovered.is_success());
+    EXPECT_EQ(recovered.value(), 100);
+}
+TEST(OutcomeTest, OrElseErrorOther) {
+    Outcome<int, IOError> result = Err(IOError::FileNotFound);
+    auto recovered = result.or_else([]() {
+        return Outcome<int, NetworkError>(100);
+    });
+    EXPECT_TRUE(recovered.is_success());
+    EXPECT_EQ(recovered.value(), 100);
+}
+// ============================================================================
+// Monadic Operations - transform
+// ============================================================================
+
+TEST(OutcomeTest, TransformSuccess) {
+    Outcome<int, IOError> result(5);
+    auto squared = result.transform([](int x) { return x * x; });
+    EXPECT_TRUE(squared.is_success());
+    EXPECT_EQ(squared.value(), 25);
+}
+
+TEST(OutcomeTest, TransformError) {
+    Outcome<int, IOError> result = Err(IOError::FileNotFound);
+    auto squared = result.transform([](int x) { return x * x; });
+    EXPECT_TRUE(squared.is_error());
+    EXPECT_EQ(squared.error<IOError>(), IOError::FileNotFound);
+}
+
+TEST(OutcomeTest, TransformTypeChange) {
+    Outcome<int, IOError> result(42);
+    auto str_result = result.transform([](int x) { return std::to_string(x); });
+    static_assert(std::is_same_v<decltype(str_result)::value_type, std::string>);
+    EXPECT_TRUE(str_result.is_success());
+    EXPECT_EQ(str_result.value(), "42");
+}
+
+TEST(OutcomeTest, TransformChaining) {
+    auto result = Outcome<int, IOError>(10)
+                      .transform([](int x) { return x + 5; })
+                      .transform([](int x) { return x * 2; })
+                      .transform([](int x) { return std::to_string(x); });
+    EXPECT_TRUE(result.is_success());
+    EXPECT_EQ(result.value(), "30");
+}
+
+// ============================================================================
+// Visit Pattern Tests
+// ============================================================================
+
+TEST(OutcomeTest, VisitSuccess) {
+    Outcome<int, IOError, NetworkError> result(42);
+    int value = result.visit(
+        [](int x) { return x; },
+        [](IOError) { return -1; },
+        [](NetworkError) { return -2; }
+    );
+    EXPECT_EQ(value, 42);
+}
+
+TEST(OutcomeTest, VisitIOError) {
+    Outcome<int, IOError, NetworkError> result = Err(IOError::FileNotFound);
+    int value = result.visit(
+        []([[maybe_unused]] int x) { return 0; },
+        [](IOError err) { return static_cast<int>(err) + 10; },
+        [](NetworkError) { return -1; }
+    );
+    EXPECT_EQ(value, 10);
+}
+
+TEST(OutcomeTest, VisitNetworkError) {
+    Outcome<int, IOError, NetworkError> result = Err(NetworkError::Timeout);
+    int value = result.visit(
+        []([[maybe_unused]] int x) { return 0; },
+        [](IOError) { return -1; },
+        [](NetworkError err) { return static_cast<int>(err) + 20; }
+    );
+    EXPECT_EQ(value, 20);
+}
+
+// ============================================================================
+// Void Specialization Tests
+// ============================================================================
+
+TEST(OutcomeVoidTest, DefaultConstruction) {
+    Outcome<void, IOError> result;
+    EXPECT_TRUE(result.is_success());
+    EXPECT_FALSE(result.is_error());
+}
+
+TEST(OutcomeVoidTest, ConstructionFromMonostate) {
+    Outcome<void, IOError> result = Ok();
+    EXPECT_TRUE(result.is_success());
+}
+
+TEST(OutcomeVoidTest, ConstructionFromError) {
+    Outcome<void, IOError> result = Err(IOError::PermissionDenied);
+    EXPECT_TRUE(result.is_error());
+    EXPECT_EQ(result.error<IOError>(), IOError::PermissionDenied);
+}
+
+TEST(OutcomeVoidTest, SuccessFactory) {
+    auto result = Outcome<void, IOError>::success();
+    EXPECT_TRUE(result.is_success());
+}
+
+TEST(OutcomeVoidTest, ErrorFactory) {
+    auto result = Outcome<void, IOError>::error(IOError::DiskFull);
+    EXPECT_TRUE(result.is_error());
+    EXPECT_EQ(result.error<IOError>(), IOError::DiskFull);
+}
+
+TEST(OutcomeVoidTest, OperatorBool) {
+    Outcome<void, IOError> success;
+    EXPECT_TRUE(static_cast<bool>(success));
+
+    Outcome<void, IOError> error = Err(IOError::FileNotFound);
+    EXPECT_FALSE(static_cast<bool>(error));
+}
+
+TEST(OutcomeVoidTest, EnsureSuccess) {
+    Outcome<void, IOError> success;
+    EXPECT_NO_THROW(success.ensure_success());
+
+    Outcome<void, IOError> error = Err(IOError::FileNotFound);
+    EXPECT_THROW(error.ensure_success(), std::bad_variant_access);
+}
+
+TEST(OutcomeVoidTest, AndThen) {
+    auto result = Outcome<void, IOError>().and_then([]() {
+        return Outcome<int, IOError>(42);
+    });
+    EXPECT_TRUE(result.is_success());
+    EXPECT_EQ(result.value(), 42);
+
+    auto error_result = Outcome<void, IOError>::error(IOError::FileNotFound)
+                            .and_then([]() {
+                                return Outcome<int, IOError>(42);
+                            });
+    EXPECT_TRUE(error_result.is_error());
+    EXPECT_EQ(error_result.error<IOError>(), IOError::FileNotFound);
+}
+
+TEST(OutcomeVoidTest, OrElse) {
+    auto success = Outcome<void, IOError>().or_else([]() {
+        return Outcome<void, IOError>::error(IOError::DiskFull);
+    });
+    EXPECT_TRUE(success.is_success());
+
+    auto recovered = Outcome<void, IOError>::error(IOError::FileNotFound)
+                         .or_else([]() {
+                             return Outcome<void, IOError>();
+                         });
+    EXPECT_TRUE(recovered.is_success());
+}
+
+TEST(OutcomeVoidTest, Transform) {
+    auto result = Outcome<void, IOError>().transform([]() {
+        return 42;
+    });
+    EXPECT_TRUE(result.is_success());
+    EXPECT_EQ(result.value(), 42);
+
+    auto error_result = Outcome<void, IOError>::error(IOError::FileNotFound)
+                            .transform([]() {
+                                return 42;
+                            });
+    EXPECT_TRUE(error_result.is_error());
+}
+
+TEST(OutcomeVoidTest, Visit) {
+    Outcome<void, IOError, NetworkError> success;
+    int value = success.visit(
+        [](std::monostate) { return 0; },
+        [](IOError) { return 1; },
+        [](NetworkError) { return 2; }
+    );
+    EXPECT_EQ(value, 0);
+
+    Outcome<void, IOError, NetworkError> error = Err(IOError::DiskFull);
+    value = error.visit(
+        [](std::monostate) { return 0; },
+        [](IOError err) { return static_cast<int>(err) + 10; },
+        [](NetworkError) { return 2; }
+    );
+    EXPECT_EQ(value, 12);
+}
+
+// ============================================================================
+// Combine Outcomes Tests
+// ============================================================================
+
+TEST(CombineOutcomesTest, AllSuccessNonVoid) {
+    //?
+}
+
+TEST(CombineOutcomesTest, AllSuccessVoid) {
+    Outcome<void, IOError> r1;
+    Outcome<void, IOError> r2;
+    Outcome<void, IOError> r3;
+
+    auto combined = combine_outcomes(r1, r2, r3);
+    EXPECT_TRUE(combined.is_success());
+}
+
+TEST(CombineOutcomesTest, FirstError) {
+    Outcome<int, IOError> r1 = Err(IOError::FileNotFound);
+    Outcome<int, IOError> r2(20);
+    Outcome<int, IOError> r3(30);
+
+    auto combined = combine_outcomes(r1, r2, r3);
+    EXPECT_TRUE(combined.is_error());
+}
+
+TEST(CombineOutcomesTest, MiddleError) {
+    Outcome<int, IOError> r1(10);
+    Outcome<int, IOError> r2 = Err(IOError::PermissionDenied);
+    Outcome<int, IOError> r3(30);
+
+    auto combined = combine_outcomes(r1, r2, r3);
+    EXPECT_TRUE(combined.is_error());
+}
+
+TEST(CombineOutcomesTest, MixedVoidAndNonVoid) {
+    Outcome<void, IOError> r1;
+    Outcome<int, IOError> r2(42);
+    Outcome<std::string, IOError> r3("hello");
+
+    auto combined = combine_outcomes(r1, r2, r3);
+    EXPECT_TRUE(combined.is_success());
+    EXPECT_EQ(std::get<0>(combined.value()), 42);
+    EXPECT_EQ(std::get<1>(combined.value()), "hello");
+}
+
+// ============================================================================
+// Real-World Usage Examples
+// ============================================================================
+
+// File reading example
+Outcome<std::string, IOError> read_file(const std::string& path) {
+    if (path.empty()) {
+        return Err(IOError::FileNotFound);
+    }
+    if (path == "forbidden") {
+        return Err(IOError::PermissionDenied);
+    }
+    return Ok(std::string("file contents"));
+}
+
+TEST(RealWorldTest, FileReadingSuccess) {
+    auto result = read_file("test.txt");
+    EXPECT_TRUE(result.is_success());
+    EXPECT_EQ(result.value(), "file contents");
+}
+
+TEST(RealWorldTest, FileReadingError) {
+    auto result = read_file("");
+    EXPECT_TRUE(result.is_error());
+    EXPECT_EQ(result.error<IOError>(), IOError::FileNotFound);
+}
+
+TEST(RealWorldTest, FileReadingChain) {
+    auto result = read_file("test.txt")
+                      .transform([](const std::string& content) {
+                          return content.size();
+                      })
+                      .and_then([](size_t size) {
+                          return Outcome<int, IOError>(static_cast<int>(size) * 2);
+                      });
+    EXPECT_TRUE(result.is_success());
+    EXPECT_EQ(result.value(), 26);  // "file contents" = 13 chars * 2
+}
+
+// Network request example
+Outcome<std::string, NetworkError, ParseError> fetch_and_parse(const std::string& url) {
+    if (url.empty()) {
+        return Err(NetworkError::InvalidResponse);
+    }
+    if (url == "timeout") {
+        return Err(NetworkError::Timeout);
+    }
+    if (url == "invalid_json") {
+        return Err(ParseError{"Invalid JSON", 1});
+    }
+    return Ok(std::string("parsed data"));
+}
+
+TEST(RealWorldTest, NetworkRequestSuccess) {
+    auto result = fetch_and_parse("https://api.example.com");
+    EXPECT_TRUE(result.is_success());
+    EXPECT_EQ(result.value(), "parsed data");
+}
+
+TEST(RealWorldTest, NetworkRequestTimeout) {
+    auto result = fetch_and_parse("timeout");
+    EXPECT_TRUE(result.is_error());
+    EXPECT_TRUE(result.holds_error<NetworkError>());
+    EXPECT_EQ(result.error<NetworkError>(), NetworkError::Timeout);
+}
+
+TEST(RealWorldTest, NetworkRequestParseError) {
+    auto result = fetch_and_parse("invalid_json");
+    EXPECT_TRUE(result.is_error());
+    EXPECT_TRUE(result.holds_error<ParseError>());
+    EXPECT_EQ(result.error<ParseError>().line_number, 1);
+}
+
+// ============================================================================
+// Edge Cases and Special Scenarios
+// ============================================================================
+
+TEST(EdgeCaseTest, MoveOnlyType) {
+    Outcome<std::unique_ptr<int>, IOError> result = Ok(std::make_unique<int>(42));
+    EXPECT_TRUE(result.is_success());
+    EXPECT_EQ(*result.value(), 42);
+
+    auto value = std::move(result).value();
+    EXPECT_EQ(*value, 42);
+}
+
+TEST(EdgeCaseTest, LargeValueType) {
+    std::vector<int> large_vec(1000, 42);
+    Outcome<std::vector<int>, IOError> result = Ok(large_vec);
+    EXPECT_TRUE(result.is_success());
+    EXPECT_EQ(result.value().size(), 1000);
+}
+
+TEST(EdgeCaseTest, ConstCorrectness) {
+    const Outcome<int, IOError> result(42);
+    EXPECT_EQ(result.value(), 42);
+    EXPECT_EQ(*result, 42);
+
+    const Outcome<int, IOError> error = Err(IOError::FileNotFound);
+    EXPECT_EQ(error.error<IOError>(), IOError::FileNotFound);
+}

--- a/tests/unit_tests/gears/test_outcome.cpp
+++ b/tests/unit_tests/gears/test_outcome.cpp
@@ -86,8 +86,7 @@ TEST(OutcomeTest, ErrorFactoryMethod) {
 
 TEST(OutcomeTest, ConstructionWithComplexType) {
     ParseError err{"Invalid syntax", 42};
-    Err(std::move(err));
-    Outcome<std::string, ParseError> result;
+    Outcome<std::string, ParseError> result = Err((err));
     EXPECT_TRUE(result.is_error());
     EXPECT_EQ(result.error<ParseError>(), err);
 }
@@ -486,7 +485,7 @@ Outcome<std::string, NetworkError, ParseError> fetch_and_parse(const std::string
     if (url == "invalid_json") {
         return Err(ParseError{"Invalid JSON", 1});
     }
-    return Ok(std::string("parsed data"));
+    return "parsed data";
 }
 
 TEST(RealWorldTest, NetworkRequestSuccess) {


### PR DESCRIPTION
### Description

This pull request introduces the `Outcome` construct to manage success and error states in a type-safe manner. Key updates include:

- Added `Outcome` construct for enhanced error and success state handling.
- Refactored `Result` to `ExceptionResult` to align with the new structure.
- Enhanced `combine_outcomes` utility for improved functionality.
- Updated related tests and build configurations to support changes.
- Added sandbox files to `.gitignore`.

These changes aim to improve error management consistency and provide better utilities for state handling.