### PR TITLE
Add platform-specific thread ID support and improve logging

### DIFF
--- a/common/scroll/entry/include/entry_interface.hpp
+++ b/common/scroll/entry/include/entry_interface.hpp
@@ -1,9 +1,15 @@
 #pragma once
+#include <cinttypes>
 #include <cstring>
 #include <demiplane/chrono>
 #include <demiplane/gears>
 #include <source_location>
 #include <thread>
+
+#if defined(__linux__)
+    #include <sys/syscall.h>
+    #include <unistd.h>
+#endif
 
 #include "log_level.hpp"
 
@@ -24,6 +30,18 @@ namespace demiplane::scroll::detail {
         }
     };
 
+    [[nodiscard]] inline uint64_t capture_kernel_tid() noexcept {
+#if defined(__linux__)
+    #if defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 30))
+        return static_cast<uint64_t>(::gettid());
+    #else
+        return static_cast<uint64_t>(::syscall(SYS_gettid));
+    #endif
+#else
+        return std::hash<std::thread::id>{}(std::this_thread::get_id());
+#endif
+    }
+
     struct ThreadLocalCache {
         uint64_t tid;
         int32_t pid;
@@ -31,9 +49,9 @@ namespace demiplane::scroll::detail {
         char pid_str[16]{};
 
         ThreadLocalCache() noexcept {
-            tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
+            tid = capture_kernel_tid();
             pid = getpid();
-            snprintf(tid_str, sizeof(tid_str), "%lu", tid);
+            snprintf(tid_str, sizeof(tid_str), "%" PRIu64, tid);
             snprintf(pid_str, sizeof(pid_str), "%d", pid);
         }
     };

--- a/common/scroll/entry/source/detailed_entry.cpp
+++ b/common/scroll/entry/source/detailed_entry.cpp
@@ -20,7 +20,13 @@ namespace demiplane::scroll {
 
         out.push_back(' ');
         out.append(level_cstr());
-        out.append(" [");
+        out.append(" [tid ");
+        out.append(tid_str);
+#ifndef __linux__
+        out.append(", pid ");
+        out.append(pid_str);
+#endif
+        out.append("] [");
 
         const char* fname = location.file_name();
         if (const char* last_slash = std::strrchr(fname, '/')) {
@@ -31,10 +37,6 @@ namespace demiplane::scroll {
         out.push_back(':');
         append_number(out, location.line());
 
-        out.append("] [tid ");
-        out.append(tid_str);
-        out.append(", pid ");
-        out.append(pid_str);
         out.append("] ");
         out.append(message_);
         out.push_back('\n');

--- a/tests/unit_tests/scroll/entry_tests.cpp
+++ b/tests/unit_tests/scroll/entry_tests.cpp
@@ -1,5 +1,6 @@
 #include <demiplane/gears>
 #include <demiplane/scroll>
+#include <limits>
 
 #include <gtest/gtest.h>
 
@@ -54,6 +55,9 @@ TEST(TestEntries, DetailedEntry) {
         check_level(output, INF);
         check_location_meta(output, loc);
     });
+#ifdef __linux__
+    EXPECT_LE(entry.tid, static_cast<uint64_t>(std::numeric_limits<int32_t>::max()));
+#endif
 }
 
 TEST(TestEntries, LightEntry) {


### PR DESCRIPTION

- Implemented `capture_kernel_tid` to obtain thread IDs with Linux-specific optimizations.
- Enhanced `ThreadLocalCache` initialization to utilize the new `capture_kernel_tid` method.
- Improved logging format to include `tid` (thread ID) and updated `pid` (process ID) usage conditionally for non-Linux platforms.
- Added unit tests to validate thread ID limits on Linux platforms.
