### PR TITLE
Add prefix support to logger system

### DIFF
--- a/benchmarks/logger/scroll_file_benchmark.cpp
+++ b/benchmarks/logger/scroll_file_benchmark.cpp
@@ -12,7 +12,8 @@ namespace {
         }
         void flush() override {
         }
-        [[nodiscard]] bool should_log(demiplane::scroll::LogLevel /*lvl*/) const noexcept override {
+        [[nodiscard]] bool should_log(demiplane::scroll::LogLevel /*lvl*/,
+                                      std::string_view /*prefix*/) const noexcept override {
             return true;
         }
     };
@@ -56,7 +57,8 @@ int main() {
         logger->add_sink(file_sink);
 
         auto result = bench::run_threaded_benchmark(bench::CONTENTION_THREADS, bench::ITERATIONS_PER_THREAD, [&] {
-            logger->log(demiplane::scroll::LogLevel::Debug, "{}", std::source_location::current(), padding);
+            logger->log(
+                demiplane::scroll::LogLevel::Debug, std::string_view{}, std::source_location::current(), "{}", padding);
         });
         logger->shutdown();
         bench::print_results(result, "Scroll", "8-Thread Contention");
@@ -81,7 +83,8 @@ int main() {
         logger->add_sink(file_sink);
 
         auto result = bench::run_threaded_benchmark(bench::BASELINE_THREADS, bench::ITERATIONS_PER_THREAD, [&] {
-            logger->log(demiplane::scroll::LogLevel::Debug, "{}", std::source_location::current(), padding);
+            logger->log(
+                demiplane::scroll::LogLevel::Debug, std::string_view{}, std::source_location::current(), "{}", padding);
         });
         logger->shutdown();
         bench::print_results(result, "Scroll", "1-Thread Baseline");
@@ -94,7 +97,8 @@ int main() {
         logger->add_sink(null_sink);
 
         auto result = bench::run_threaded_benchmark(bench::CONTENTION_THREADS, bench::ITERATIONS_PER_THREAD, [&] {
-            logger->log(demiplane::scroll::LogLevel::Debug, "{}", std::source_location::current(), padding);
+            logger->log(
+                demiplane::scroll::LogLevel::Debug, std::string_view{}, std::source_location::current(), "{}", padding);
         });
         logger->shutdown();
         bench::print_results(result, "Scroll", "8-Thread NullSink");
@@ -107,7 +111,8 @@ int main() {
         logger->add_sink(null_sink);
 
         auto result = bench::run_threaded_benchmark(bench::BASELINE_THREADS, bench::ITERATIONS_PER_THREAD, [&] {
-            logger->log(demiplane::scroll::LogLevel::Debug, "{}", std::source_location::current(), padding);
+            logger->log(
+                demiplane::scroll::LogLevel::Debug, std::string_view{}, std::source_location::current(), "{}", padding);
         });
         logger->shutdown();
         bench::print_results(result, "Scroll", "1-Thread NullSink");
@@ -135,7 +140,8 @@ int main() {
         logger->add_sink(make_file_sink("scroll_dual_b.log"));
 
         auto result = bench::run_threaded_benchmark(bench::CONTENTION_THREADS, bench::ITERATIONS_PER_THREAD, [&] {
-            logger->log(demiplane::scroll::LogLevel::Debug, "{}", std::source_location::current(), padding);
+            logger->log(
+                demiplane::scroll::LogLevel::Debug, std::string_view{}, std::source_location::current(), "{}", padding);
         });
         logger->shutdown();
         bench::print_results(result, "Scroll", "8-Thread Dual FileSink");
@@ -161,7 +167,13 @@ int main() {
         auto result = bench::run_threaded_benchmark_e2e(
             bench::CONTENTION_THREADS,
             bench::ITERATIONS_PER_THREAD,
-            [&] { logger->log(demiplane::scroll::LogLevel::Debug, "{}", std::source_location::current(), padding); },
+            [&] {
+                logger->log(demiplane::scroll::LogLevel::Debug,
+                            std::string_view{},
+                            std::source_location::current(),
+                            "{}",
+                            padding);
+            },
             [&] { logger->shutdown(); });
         bench::print_results(result, "Scroll", "8-Thread E2E (incl. shutdown)");
     }
@@ -190,7 +202,13 @@ int main() {
         auto result = bench::run_threaded_benchmark_e2e(
             bench::CONTENTION_THREADS,
             bench::ITERATIONS_PER_THREAD,
-            [&] { logger->log(demiplane::scroll::LogLevel::Debug, "{}", std::source_location::current(), padding); },
+            [&] {
+                logger->log(demiplane::scroll::LogLevel::Debug,
+                            std::string_view{},
+                            std::source_location::current(),
+                            "{}",
+                            padding);
+            },
             [&] { logger->shutdown(); });
         bench::print_results(result, "Scroll", "8-Thread Dual E2E (incl. shutdown)");
     }

--- a/common/gears/strings/gears_strings.hpp
+++ b/common/gears/strings/gears_strings.hpp
@@ -5,8 +5,8 @@
 #include <string_view>
 
 namespace demiplane::gears {
-    template <std::size_t N>
 
+    template <std::size_t N>
     struct FixedString {
         char data[N] = {};
 
@@ -93,7 +93,7 @@ namespace demiplane::gears {
             return {data_, size_};
         }
 
-        [[nodiscard]] explicit constexpr operator std::string_view() const noexcept {
+        [[nodiscard]] constexpr explicit operator std::string_view() const noexcept {
             return view();
         }
 

--- a/common/gears/strings/gears_strings.hpp
+++ b/common/gears/strings/gears_strings.hpp
@@ -65,6 +65,30 @@ namespace demiplane::gears {
             return *this;
         }
 
+        /// Replace contents with @p sv. At runtime, truncates silently if
+        /// @p sv exceeds Capacity. At consteval, throws on overflow — which is
+        /// a compile error, providing compile-time size checking for literal
+        /// sources.
+        constexpr InlineString& assign(std::string_view sv) {
+            if consteval {
+                if (sv.size() > Capacity) {
+                    throw std::out_of_range("InlineString: assign exceeds capacity");
+                }
+            }
+            const std::size_t n = std::min(sv.size(), Capacity);
+            for (std::size_t i = 0; i < n; ++i) {
+                data_[i] = sv[i];
+            }
+            data_[n] = '\0';
+            size_    = n;
+            return *this;
+        }
+
+        constexpr void clear() noexcept {
+            size_    = 0;
+            data_[0] = '\0';
+        }
+
         [[nodiscard]] constexpr std::string_view view() const noexcept {
             return {data_, size_};
         }

--- a/common/scroll/CMakeLists.txt
+++ b/common/scroll/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(${DMP_SCROLL}.Entry PUBLIC
 add_library(${DMP_SCROLL}.Sink.Interface INTERFACE
         sink/interface/sink_interface.hpp
         sink/interface/log_event.hpp
+        sink/interface/prefix_filter.hpp
 )
 
 target_include_directories(${DMP_SCROLL}.Sink.Interface INTERFACE

--- a/common/scroll/entry/include/detailed_entry.hpp
+++ b/common/scroll/entry/include/detailed_entry.hpp
@@ -5,8 +5,11 @@
 #include "entry_interface.hpp"
 
 namespace demiplane::scroll {
-    class DetailedEntry final
-        : public detail::EntryBase<detail::MetaTimePoint, detail::MetaSource, detail::MetaThread, detail::MetaProcess> {
+    class DetailedEntry final : public detail::EntryBase<detail::MetaTimePoint,
+                                                         detail::MetaSource,
+                                                         detail::MetaThread,
+                                                         detail::MetaProcess,
+                                                         detail::MetaPrefix> {
     public:
         using EntryBase::EntryBase;
 
@@ -24,6 +27,6 @@ namespace demiplane::scroll {
     // Traits for the new fast entry
     template <>
     struct detail::entry_traits<DetailedEntry> {
-        using wants = gears::type_list<MetaTimePoint, MetaSource, MetaThread, MetaProcess>;
+        using wants = gears::type_list<MetaTimePoint, MetaSource, MetaThread, MetaProcess, MetaPrefix>;
     };
 }  // namespace demiplane::scroll

--- a/common/scroll/entry/include/entry_interface.hpp
+++ b/common/scroll/entry/include/entry_interface.hpp
@@ -1,6 +1,6 @@
 #pragma once
+
 #include <cinttypes>
-#include <cstring>
 #include <demiplane/chrono>
 #include <demiplane/gears>
 #include <source_location>
@@ -19,124 +19,135 @@
 
 #include "log_level.hpp"
 
-namespace demiplane::scroll::detail {
-    template <class EntryT>
-    struct entry_traits;
+namespace demiplane::scroll {
+    /// Fixed-capacity storage for class/subsystem log prefixes.
+    ///
+    /// Capacity is 31 chars + null terminator. Chosen to keep the struct
+    /// compact for per-event copies in the hot path while fitting common
+    /// class names (e.g. "PostgresAsyncExecutor" = 21 chars).
+    ///
+    /// Overflow behavior (see @ref gears::InlineString::assign):
+    /// - consteval context (literal via SCROLL_COMPONENT_PREFIX): compile error
+    /// - runtime context (set_prefix / dynamic source): silently truncates
+    using PrefixNameStorage = gears::InlineString<31>;
+    namespace detail {
+        template <class EntryT>
+        struct entry_traits;
 
+        struct MetaNone {};  // 0-B
 
-    struct MetaNone {};  // 0-B
+        struct MetaSource {
+            std::source_location location;
 
-    struct MetaSource {
-        std::source_location location;
+            MetaSource() = default;
 
-        MetaSource() = default;
+            constexpr explicit MetaSource(const std::source_location& loc) noexcept
+                : location{loc} {
+            }
+        };
 
-        explicit constexpr MetaSource(const std::source_location& loc) noexcept
-            : location{loc} {
-        }
-    };
+        struct MetaPrefix {
+            PrefixNameStorage prefix;
+            MetaPrefix() = default;
+            constexpr explicit MetaPrefix(const std::string_view sv) noexcept {
+                prefix.assign(sv);
+            }
+        };
 
-    struct MetaPrefix {
-        gears::InlineString<31> prefix;
-        MetaPrefix() = default;
-        explicit MetaPrefix(const std::string_view sv) noexcept {
-            prefix.assign(sv);
-        }
-    };
-
-    [[nodiscard]] inline uint64_t capture_kernel_tid() noexcept {
+        [[nodiscard]] inline uint64_t capture_kernel_tid() noexcept {
 #if defined(__linux__)
     #if defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 30))
-        return static_cast<uint64_t>(::gettid());
+            return static_cast<uint64_t>(::gettid());
     #else
-        return static_cast<uint64_t>(::syscall(SYS_gettid));
+            return static_cast<uint64_t>(::syscall(SYS_gettid));
     #endif
 #else
-        return std::hash<std::thread::id>{}(std::this_thread::get_id());
+            return std::hash<std::thread::id>{}(std::this_thread::get_id());
 #endif
-    }
-
-    struct ThreadLocalCache {
-        uint64_t tid;
-        int32_t pid;
-        char tid_str[16]{};
-        char pid_str[16]{};
-
-        ThreadLocalCache() noexcept {
-            tid = capture_kernel_tid();
-            pid = getpid();
-            snprintf(tid_str, sizeof(tid_str), "%" PRIu64, tid);
-            snprintf(pid_str, sizeof(pid_str), "%d", pid);
-        }
-    };
-
-    inline thread_local ThreadLocalCache tl_cache;
-
-    struct MetaThread {
-        uint64_t tid;
-        char tid_str[16]{};
-
-        MetaThread() noexcept
-            : tid{tl_cache.tid} {
-            std::memcpy(tid_str, tl_cache.tid_str, sizeof(tid_str));
-        }
-    };
-
-    struct MetaProcess {
-        int32_t pid;
-        char pid_str[16]{};
-
-        MetaProcess() noexcept
-            : pid{tl_cache.pid} {
-            std::memcpy(pid_str, tl_cache.pid_str, sizeof(pid_str));
-        }
-    };
-
-    struct MetaTimePoint {
-        std::chrono::time_point<std::chrono::system_clock> time_point;
-
-        MetaTimePoint() noexcept
-            : time_point{chrono::Clock::now()} {
-        }
-    };
-
-    template <class... Metas>
-    class EntryBase : public Metas... {
-    public:
-        EntryBase(const LogLevel lvl,
-                  const std::string_view msg,
-                  Metas... metas)  // perfect-forward meta-packs
-            : Metas{std::move(metas)}...,
-              level_{lvl},
-              message_{msg} {
         }
 
-        [[nodiscard]] LogLevel level() const noexcept {
-            return level_;
-        }
+        struct ThreadLocalCache {
+            uint64_t tid;
+            int32_t pid;
+            char tid_str[16]{};
+            char pid_str[16]{};
 
-        [[nodiscard]] std::string_view message() const noexcept {
-            return message_;
-        }
+            ThreadLocalCache() noexcept {
+                tid = capture_kernel_tid();
+                pid = getpid();
+                snprintf(tid_str, sizeof(tid_str), "%" PRIu64, tid);
+                snprintf(pid_str, sizeof(pid_str), "%d", pid);
+            }
+        };
 
-        virtual ~EntryBase()                             = default;
-        EntryBase()                                      = default;
-        virtual void format_into(std::string& out) const = 0;
+        inline thread_local ThreadLocalCache tl_cache;
 
-    protected:
-        LogLevel level_{LogLevel::Debug};
-        std::string message_;
-        static constexpr std::array<const char*, 6> level_strings = {"TRC", "DBG", "INF", "WRN", "ERR", "FAT"};
+        struct MetaThread {
+            uint64_t tid;
+            char tid_str[16]{};
 
-        [[nodiscard]] constexpr const char* level_cstr() const noexcept {
-            return level_strings[static_cast<std::size_t>(level_)];
-        }
-    };
+            MetaThread() noexcept
+                : tid{tl_cache.tid} {
+                std::memcpy(tid_str, tl_cache.tid_str, sizeof(tid_str));
+            }
+        };
 
-    template <typename T>
-    concept EntryConcept = requires(const T& entry) {
-        { entry.level() } -> std::same_as<LogLevel>;
-        { entry.message() } -> std::same_as<std::string_view>;
-        { entry.format_into(std::declval<std::string&>()) } -> std::same_as<void>;
-    };
-}  // namespace demiplane::scroll::detail
+        struct MetaProcess {
+            int32_t pid;
+            char pid_str[16]{};
+
+            MetaProcess() noexcept
+                : pid{tl_cache.pid} {
+                std::memcpy(pid_str, tl_cache.pid_str, sizeof(pid_str));
+            }
+        };
+
+        struct MetaTimePoint {
+            std::chrono::time_point<std::chrono::system_clock> time_point;
+
+            MetaTimePoint() noexcept
+                : time_point{chrono::Clock::now()} {
+            }
+        };
+
+        template <class... Metas>
+        class EntryBase : public Metas... {
+        public:
+            constexpr EntryBase(const LogLevel lvl,
+                                const std::string_view msg,
+                                Metas... metas)  // perfect-forward meta-packs
+                : Metas{std::move(metas)}...,
+                  level_{lvl},
+                  message_{msg} {
+            }
+
+            [[nodiscard]] constexpr LogLevel level() const noexcept {
+                return level_;
+            }
+
+            [[nodiscard]] constexpr std::string_view message() const noexcept {
+                return message_;
+            }
+
+            virtual ~EntryBase()                             = default;
+            EntryBase()                                      = default;
+            virtual void format_into(std::string& out) const = 0;
+
+        protected:
+            LogLevel level_{LogLevel::Debug};
+            std::string message_;
+            static constexpr std::array<const char*, 6> level_strings = {"TRC", "DBG", "INF", "WRN", "ERR", "FAT"};
+
+            [[nodiscard]] constexpr const char* level_cstr() const noexcept {
+                return level_strings[static_cast<std::size_t>(level_)];
+            }
+        };
+
+        template <typename T>
+        concept EntryConcept = requires(const T& entry) {
+            { entry.level() } -> std::same_as<LogLevel>;
+            { entry.message() } -> std::same_as<std::string_view>;
+            { entry.format_into(std::declval<std::string&>()) } -> std::same_as<void>;
+        };
+    }  // namespace detail
+}  // namespace demiplane::scroll

--- a/common/scroll/entry/include/entry_interface.hpp
+++ b/common/scroll/entry/include/entry_interface.hpp
@@ -6,9 +6,15 @@
 #include <source_location>
 #include <thread>
 
+#include <gears_strings.hpp>
+
+
 #if defined(__linux__)
-    #include <sys/syscall.h>
-    #include <unistd.h>
+    #if defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 30))
+        #include <unistd.h>
+    #else
+        #include <sys/syscall.h>
+    #endif
 #endif
 
 #include "log_level.hpp"
@@ -27,6 +33,14 @@ namespace demiplane::scroll::detail {
 
         explicit constexpr MetaSource(const std::source_location& loc) noexcept
             : location{loc} {
+        }
+    };
+
+    struct MetaPrefix {
+        gears::InlineString<31> prefix;
+        MetaPrefix() = default;
+        explicit MetaPrefix(const std::string_view sv) noexcept {
+            prefix.assign(sv);
         }
     };
 

--- a/common/scroll/entry/include/factory/entry_factory.hpp
+++ b/common/scroll/entry/include/factory/entry_factory.hpp
@@ -14,6 +14,8 @@ namespace demiplane::scroll {
                                     // Uses cached values
                                     detail::MetaProcess{},
                                     // Uses cached values
+                                    detail::MetaPrefix{},
+                                    // Empty by default; prefix is set via make_entry_from_event
                                     std::forward<Extra>(extra)...};
 
         using want_types = detail::entry_traits<EntryT>::wants;

--- a/common/scroll/entry/source/detailed_entry.cpp
+++ b/common/scroll/entry/source/detailed_entry.cpp
@@ -14,7 +14,7 @@ namespace {
 namespace demiplane::scroll {
     void DetailedEntry::format_into(std::string& out) const {
         out.clear();
-        out.reserve(128 + message_.size());
+        out.reserve(160 + message_.size());
 
         chrono::UTCClock::format_time_iso_ms(time_point, out);
 
@@ -26,8 +26,18 @@ namespace demiplane::scroll {
         out.append(", pid ");
         out.append(pid_str);
 #endif
-        out.append("] [");
+        out.append("] ");
 
+        if (!prefix.empty()) {
+            out.push_back('[');
+            out.append(prefix.view());
+            out.push_back(':');
+            const char* fn = location.function_name();
+            out.append(fn != nullptr ? fn : "?");
+            out.append("] ");
+        }
+
+        out.push_back('[');
         const char* fname = location.file_name();
         if (const char* last_slash = std::strrchr(fname, '/')) {
             fname = last_slash + 1;

--- a/common/scroll/logger/include/logger.hpp
+++ b/common/scroll/logger/include/logger.hpp
@@ -14,7 +14,6 @@
 #include <boost/asio/post.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/asio/thread_pool.hpp>
-#include <gears_strings.hpp>
 
 #include "logger_config.hpp"
 #include "sink_interface.hpp"
@@ -182,7 +181,7 @@ namespace demiplane::scroll {
                   level_{lvl},
                   loc_{std::forward<SourceLocationTp>(loc)},
                   prefix_{} {
-                prefix_.assign(prefix);
+                prefix_.assign(prefix);  // runtime: truncates silently at PrefixNameStorage capacity
             }
 
             template <typename T>
@@ -211,7 +210,7 @@ namespace demiplane::scroll {
             Logger* logger_;
             LogLevel level_;
             std::source_location loc_;
-            gears::InlineString<31> prefix_;
+            PrefixNameStorage prefix_;
             std::ostringstream stream_;
         };
 

--- a/common/scroll/logger/include/logger.hpp
+++ b/common/scroll/logger/include/logger.hpp
@@ -14,6 +14,7 @@
 #include <boost/asio/post.hpp>
 #include <boost/asio/strand.hpp>
 #include <boost/asio/thread_pool.hpp>
+#include <gears_strings.hpp>
 
 #include "logger_config.hpp"
 #include "sink_interface.hpp"
@@ -100,46 +101,45 @@ namespace demiplane::scroll {
         }
 
         /**
-         * @brief Log with format string (C++20 std::format)
-         * @tparam Args Argument types
+         * @brief Log with format string (C++20 std::format) + prefix
          * @param lvl Log level
+         * @param prefix Logger / class prefix; empty if none
+         * @param loc Source location
          * @param fmt Format string
-         * @param loc Source location (auto-captured)
          * @param args Arguments to format
-         *
-         * Usage:
-         *   logger.log(LogLevel::Info, "User {} has {} items", username, count);
          */
         template <typename... Args>
-        constexpr void
-        log(const LogLevel lvl, std::format_string<Args...> fmt, const std::source_location& loc, Args&&... args) {
+        constexpr void log(const LogLevel lvl,
+                           const std::string_view prefix,
+                           const std::source_location& loc,
+                           std::format_string<Args...> fmt,
+                           Args&&... args) {
             // COROUTINE SAFETY: No suspension points allowed between tl_msg_buf usage and swap.
-            // This TL buffer is safe as long as format→swap is non-interruptible.
             thread_local std::string tl_msg_buf;
             tl_msg_buf.clear();
             std::format_to(std::back_inserter(tl_msg_buf), fmt, std::forward<Args>(args)...);
             const auto meta = EventMeta{lvl, loc};
 
-            // Critical path: claim → swap → publish (minimal time holding slot)
             const std::int64_t seq = disruptor_.sequencer().next();
             auto& event            = disruptor_.ring_buffer()[seq];
 
             event.message.swap(tl_msg_buf);
+            event.prefix.assign(prefix);
             apply_meta(event, meta);
 
             disruptor_.sequencer().publish(seq);
+            // TODO(scroll/logger): formatted-message cost is paid even when all
+            // sinks filter the event out. Consider moving format to sinks
+            // (requires type-erased args) or querying sink filters before format.
         }
 
         /**
-         * @brief Log with simple message (no formatting)
-         * @param lvl Log level
-         * @param msg Message
-         * @param loc Source location (auto-captured)
+         * @brief Log with a simple message + prefix
          */
         constexpr void log(const LogLevel lvl,
+                           const std::string_view prefix,
                            const std::string_view msg,
                            const std::source_location& loc = std::source_location::current()) {
-            // COROUTINE SAFETY: No suspension points allowed between tl_msg_buf usage and swap.
             thread_local std::string tl_msg_buf;
             tl_msg_buf.clear();
             tl_msg_buf.append(msg);
@@ -149,27 +149,40 @@ namespace demiplane::scroll {
             auto& event            = disruptor_.ring_buffer()[seq];
 
             event.message.swap(tl_msg_buf);
+            event.prefix.assign(prefix);
             apply_meta(event, meta);
 
             disruptor_.sequencer().publish(seq);
         }
 
         /**
-         * @brief Stream-based logging proxy
+         * @brief Shorthand: log with simple message, no prefix.
          *
-         * Accumulates stream operations and publishes on destruction.
-         *
-         * Usage:
-         *   logger.stream(LogLevel::Info) << "User " << username << " logged in";
+         * Kept permanently for callers that don't care about prefix (tests,
+         * utility code). Forwards to the prefix-aware overload with empty prefix.
+         */
+        constexpr void log(const LogLevel lvl,
+                           const std::string_view msg,
+                           const std::source_location& loc = std::source_location::current()) {
+            log(lvl, std::string_view{}, msg, loc);
+        }
+
+        /**
+         * @brief Stream-based logging proxy carrying level + prefix + source location
          */
         class StreamProxy {
         public:
             template <typename SourceLocationTp = std::source_location>
                 requires std::is_same_v<std::remove_cvref_t<SourceLocationTp>, std::source_location>
-            constexpr StreamProxy(Logger* logger, const LogLevel lvl, SourceLocationTp&& loc) noexcept
+            constexpr StreamProxy(Logger* logger,
+                                  const LogLevel lvl,
+                                  const std::string_view prefix,
+                                  SourceLocationTp&& loc) noexcept
                 : logger_{logger},
                   level_{lvl},
-                  loc_{std::forward<SourceLocationTp>(loc)} {
+                  loc_{std::forward<SourceLocationTp>(loc)},
+                  prefix_{} {
+                prefix_.assign(prefix);
             }
 
             template <typename T>
@@ -179,7 +192,6 @@ namespace demiplane::scroll {
             }
 
             constexpr ~StreamProxy() noexcept {
-                // COROUTINE SAFETY: No suspension points allowed between tl_msg_buf usage and swap.
                 thread_local std::string tl_msg_buf;
                 tl_msg_buf.clear();
                 tl_msg_buf.append(stream_.view());
@@ -189,6 +201,7 @@ namespace demiplane::scroll {
                 auto& event            = logger_->disruptor_.ring_buffer()[seq];
 
                 event.message.swap(tl_msg_buf);
+                event.prefix.assign(prefix_.view());
                 apply_meta(event, meta);
 
                 logger_->disruptor_.sequencer().publish(seq);
@@ -198,13 +211,15 @@ namespace demiplane::scroll {
             Logger* logger_;
             LogLevel level_;
             std::source_location loc_;
+            gears::InlineString<31> prefix_;
             std::ostringstream stream_;
         };
 
         template <typename SourceLocationTp = std::source_location>
             requires std::is_same_v<std::remove_cvref_t<SourceLocationTp>, std::source_location>
-        constexpr StreamProxy stream(const LogLevel lvl, SourceLocationTp loc = std::source_location::current()) {
-            return StreamProxy{this, lvl, std::forward<SourceLocationTp>(loc)};
+        constexpr StreamProxy
+        stream(const LogLevel lvl, std::string_view prefix, SourceLocationTp loc = std::source_location::current()) {
+            return StreamProxy{this, lvl, prefix, std::forward<SourceLocationTp>(loc)};
         }
 
         /**

--- a/common/scroll/provider/include/log_macros.hpp
+++ b/common/scroll/provider/include/log_macros.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <string_view>
+
 #include <gears_macros.hpp>
+#include <gears_strings.hpp>
 
 namespace demiplane::scroll {
     // Dummy stream for disabled logging
@@ -14,105 +17,112 @@ namespace demiplane::scroll {
 }  // namespace demiplane::scroll
 
 // ============================================================================
-// Macro overloading utilities (using C++20 __VA_OPT__)
+// Declares a class-scope prefix for COMPONENT_LOG_*.
+//
+// Usage inside a class body:
+//     class Server {
+//     private:
+//         SCROLL_COMPONENT_PREFIX("Server");
+//         ...
+//     };
+//
+// The IIFE initializer runs at compile time; oversized names trigger the
+// consteval-throw path in InlineString::assign → compile error.
 // ============================================================================
-
-// Override HAS_ARGS to properly detect empty arguments using __VA_OPT__
-
+#define SCROLL_COMPONENT_PREFIX(name)                                                                                  \
+    static constexpr ::demiplane::gears::InlineString<31> _dmp_scroll_class_prefix = [] {                              \
+        ::demiplane::gears::InlineString<31> s;                                                                        \
+        s.assign(::std::string_view{name});                                                                            \
+        return s;                                                                                                      \
+    }()
 
 // ============================================================================
-// Overloaded macros: LOG_DBG() uses stream, LOG_DBG("fmt", ...) uses format
+// Sets the prefix on a LoggerProvider-derived object from inside its
+// constructor body. Runtime call — overflow silently truncates.
 // ============================================================================
+#define SCROLL_SET_LOGGER_PREFIX(name) this->set_prefix(::std::string_view{name})
 
 #ifdef DMP_ENABLE_LOGGING
-    /**
-     * @brief Log with format string and arguments OR stream operators
-     *
-     * Usage:
-     *   LOG_INF("User {} logged in from {}", username, ip_address);  // Format style
-     *   LOG_INF() << "User " << username << " logged in";            // Stream style
-     */
-
-    // ========== TRACE ==========
+   // ========== LOG_* (LoggerProvider path) ==========
     #define LOG_TRC_STREAM()                                                                                           \
-        this->get_logger()->stream(::demiplane::scroll::LogLevel::Trace,               \
-                                                                   std::source_location::current())
-
+        this->get_logger()->stream(                                                                                    \
+            ::demiplane::scroll::LogLevel::Trace, this->prefix().view(), std::source_location::current())
     #define LOG_TRC_FMT(fmt, ...)                                                                                      \
-        this->get_logger()->log(                                                       \
-            ::demiplane::scroll::LogLevel::Trace, fmt, std::source_location::current(), __VA_ARGS__)
-
+        this->get_logger()->log(::demiplane::scroll::LogLevel::Trace,                                                  \
+                                this->prefix().view(),                                                                 \
+                                std::source_location::current(),                                                       \
+                                fmt,                                                                                   \
+                                __VA_ARGS__)
     #define LOG_TRC_DISPATCH_() LOG_TRC_STREAM()
     #define LOG_TRC_DISPATCH_TRUE(...) LOG_TRC_FMT(__VA_ARGS__)
     #define LOG_TRC(...) CONCAT(LOG_TRC_DISPATCH_, HAS_ARGS(__VA_ARGS__))(__VA_ARGS__)
 
-    // ========== DEBUG ==========
     #define LOG_DBG_STREAM()                                                                                           \
-        this->get_logger()->stream(::demiplane::scroll::LogLevel::Debug,               \
-                                                                   std::source_location::current())
-
+        this->get_logger()->stream(                                                                                    \
+            ::demiplane::scroll::LogLevel::Debug, this->prefix().view(), std::source_location::current())
     #define LOG_DBG_FMT(fmt, ...)                                                                                      \
-        this->get_logger()->log(                                                       \
-            ::demiplane::scroll::LogLevel::Debug, fmt, std::source_location::current(), __VA_ARGS__)
-
+        this->get_logger()->log(::demiplane::scroll::LogLevel::Debug,                                                  \
+                                this->prefix().view(),                                                                 \
+                                std::source_location::current(),                                                       \
+                                fmt,                                                                                   \
+                                __VA_ARGS__)
     #define LOG_DBG_DISPATCH_() LOG_DBG_STREAM()
     #define LOG_DBG_DISPATCH_TRUE(...) LOG_DBG_FMT(__VA_ARGS__)
     #define LOG_DBG(...) CONCAT(LOG_DBG_DISPATCH_, HAS_ARGS(__VA_ARGS__))(__VA_ARGS__)
 
-    // ========== INFO ==========
     #define LOG_INF_STREAM()                                                                                           \
-        this->get_logger()->stream(::demiplane::scroll::LogLevel::Info,                \
-                                                                   std::source_location::current())
-
+        this->get_logger()->stream(                                                                                    \
+            ::demiplane::scroll::LogLevel::Info, this->prefix().view(), std::source_location::current())
     #define LOG_INF_FMT(fmt, ...)                                                                                      \
-        this->get_logger()->log(                                                       \
-            ::demiplane::scroll::LogLevel::Info, fmt, std::source_location::current(), __VA_ARGS__)
-
+        this->get_logger()->log(::demiplane::scroll::LogLevel::Info,                                                   \
+                                this->prefix().view(),                                                                 \
+                                std::source_location::current(),                                                       \
+                                fmt,                                                                                   \
+                                __VA_ARGS__)
     #define LOG_INF_DISPATCH_() LOG_INF_STREAM()
     #define LOG_INF_DISPATCH_TRUE(...) LOG_INF_FMT(__VA_ARGS__)
     #define LOG_INF(...) CONCAT(LOG_INF_DISPATCH_, HAS_ARGS(__VA_ARGS__))(__VA_ARGS__)
 
-    // ========== WARNING ==========
     #define LOG_WRN_STREAM()                                                                                           \
-        this->get_logger()->stream(::demiplane::scroll::LogLevel::Warning,             \
-                                                                   std::source_location::current())
-
+        this->get_logger()->stream(                                                                                    \
+            ::demiplane::scroll::LogLevel::Warning, this->prefix().view(), std::source_location::current())
     #define LOG_WRN_FMT(fmt, ...)                                                                                      \
-        this->get_logger()->log(                                                       \
-            ::demiplane::scroll::LogLevel::Warning, fmt, std::source_location::current(), __VA_ARGS__)
-
+        this->get_logger()->log(::demiplane::scroll::LogLevel::Warning,                                                \
+                                this->prefix().view(),                                                                 \
+                                std::source_location::current(),                                                       \
+                                fmt,                                                                                   \
+                                __VA_ARGS__)
     #define LOG_WRN_DISPATCH_() LOG_WRN_STREAM()
     #define LOG_WRN_DISPATCH_TRUE(...) LOG_WRN_FMT(__VA_ARGS__)
     #define LOG_WRN(...) CONCAT(LOG_WRN_DISPATCH_, HAS_ARGS(__VA_ARGS__))(__VA_ARGS__)
 
-    // ========== ERROR ==========
     #define LOG_ERR_STREAM()                                                                                           \
-        this->get_logger()->stream(::demiplane::scroll::LogLevel::Error,               \
-                                                                   std::source_location::current())
-
+        this->get_logger()->stream(                                                                                    \
+            ::demiplane::scroll::LogLevel::Error, this->prefix().view(), std::source_location::current())
     #define LOG_ERR_FMT(fmt, ...)                                                                                      \
-        this->get_logger()->log(                                                       \
-            ::demiplane::scroll::LogLevel::Error, fmt, std::source_location::current(), __VA_ARGS__)
-
+        this->get_logger()->log(::demiplane::scroll::LogLevel::Error,                                                  \
+                                this->prefix().view(),                                                                 \
+                                std::source_location::current(),                                                       \
+                                fmt,                                                                                   \
+                                __VA_ARGS__)
     #define LOG_ERR_DISPATCH_() LOG_ERR_STREAM()
     #define LOG_ERR_DISPATCH_TRUE(...) LOG_ERR_FMT(__VA_ARGS__)
     #define LOG_ERR(...) CONCAT(LOG_ERR_DISPATCH_, HAS_ARGS(__VA_ARGS__))(__VA_ARGS__)
 
-    // ========== FATAL ==========
     #define LOG_FAT_STREAM()                                                                                           \
-        this->get_logger()->stream(::demiplane::scroll::LogLevel::Fatal,               \
-                                                                   std::source_location::current())
-
+        this->get_logger()->stream(                                                                                    \
+            ::demiplane::scroll::LogLevel::Fatal, this->prefix().view(), std::source_location::current())
     #define LOG_FAT_FMT(fmt, ...)                                                                                      \
-        this->get_logger()->log(                                                       \
-            ::demiplane::scroll::LogLevel::Fatal, fmt, std::source_location::current(), __VA_ARGS__)
-
+        this->get_logger()->log(::demiplane::scroll::LogLevel::Fatal,                                                  \
+                                this->prefix().view(),                                                                 \
+                                std::source_location::current(),                                                       \
+                                fmt,                                                                                   \
+                                __VA_ARGS__)
     #define LOG_FAT_DISPATCH_() LOG_FAT_STREAM()
     #define LOG_FAT_DISPATCH_TRUE(...) LOG_FAT_FMT(__VA_ARGS__)
     #define LOG_FAT(...) CONCAT(LOG_FAT_DISPATCH_, HAS_ARGS(__VA_ARGS__))(__VA_ARGS__)
 
     // ========== ONCE GUARDS ==========
-    // Each expansion site gets its own static flag via the lambda
     #define SCROLL_ONCE_GUARD_                                                                                         \
         []() -> bool {                                                                                                 \
             static bool f_ = false;                                                                                    \
@@ -125,7 +135,6 @@ namespace demiplane::scroll {
             return !f_.exchange(true, std::memory_order_relaxed);                                                      \
         }()
 
-    // ========== LOG_*_ONCE (static bool guard) ==========
     #define LOG_TRC_ONCE(...)                                                                                          \
         if (SCROLL_ONCE_GUARD_)                                                                                        \
         LOG_TRC(__VA_ARGS__)
@@ -145,7 +154,6 @@ namespace demiplane::scroll {
         if (SCROLL_ONCE_GUARD_)                                                                                        \
         LOG_FAT(__VA_ARGS__)
 
-    // ========== LOG_*_ATOMIC_ONCE (std::atomic<bool> guard) ==========
     #define LOG_TRC_ATOMIC_ONCE(...)                                                                                   \
         if (SCROLL_ATOMIC_ONCE_GUARD_)                                                                                 \
         LOG_TRC(__VA_ARGS__)
@@ -166,7 +174,6 @@ namespace demiplane::scroll {
         LOG_FAT(__VA_ARGS__)
 
 #else
-   // Disabled logging - all macros become no-ops
     #define LOG_TRC(...) ::demiplane::scroll::DummyStream()
     #define LOG_DBG(...) ::demiplane::scroll::DummyStream()
     #define LOG_INF(...) ::demiplane::scroll::DummyStream()
@@ -190,93 +197,119 @@ namespace demiplane::scroll {
 #endif
 
 // ============================================================================
-// Direct logger macros (for custom logger instances) TODO: make it looks like LOG_DIRECT_TRC wihout FMT or STREAM
+// LOG_DIRECT_* — explicit prefix parameter. Used by test code and rare
+// non-LoggerProvider call sites.
 // ============================================================================
-
 #ifdef DMP_ENABLE_LOGGING
-    /**
-     * @brief Log to a specific logger instance (not global)
-     *
-     * Usage:
-     *   Logger* my_logger = get_logger();
-     *   LOG_DIRECT_FMT_INF(my_logger, "User {} connected", user_id);
-     *   LOG_DIRECT_STREAM_DBG(my_logger) << "Debug info: " << data;
-     */
-    #define LOG_DIRECT_FMT(logger_ptr, level, fmt, ...)                                                                    \
-        (logger_ptr)->log(level, fmt, std::source_location::current(), __VA_ARGS__)
+    #define LOG_DIRECT_FMT(logger_ptr, level, prefix, fmt, ...)                                                        \
+        (logger_ptr)->log(level, prefix, std::source_location::current(), fmt, __VA_ARGS__)
 
-    #define SLOG_DIRECT_FMT(logger_ptr, level) (logger_ptr)->stream(level, std::source_location::current())
+    #define SLOG_DIRECT_FMT(logger_ptr, level, prefix)                                                                 \
+        (logger_ptr)->stream(level, prefix, std::source_location::current())
 
-    // Convenience wrappers
-    #define LOG_DIRECT_FMT_TRC(logger_ptr, fmt, ...)                                                                       \
-        LOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Trace, fmt, __VA_ARGS__)
-    #define LOG_DIRECT_FMT_DBG(logger_ptr, fmt, ...)                                                                       \
-        LOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Debug, fmt, __VA_ARGS__)
-    #define LOG_DIRECT_FMT_INF(logger_ptr, fmt, ...)                                                                       \
-        LOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Info, fmt, __VA_ARGS__)
-    #define LOG_DIRECT_FMT_WRN(logger_ptr, fmt, ...)                                                                       \
-        LOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Warning, fmt, __VA_ARGS__)
-    #define LOG_DIRECT_FMT_ERR(logger_ptr, fmt, ...)                                                                       \
-        LOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Error, fmt, __VA_ARGS__)
-    #define LOG_DIRECT_FMT_FAT(logger_ptr, fmt, ...)                                                                       \
-        LOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Fatal, fmt, __VA_ARGS__)
+    #define LOG_DIRECT_FMT_TRC(logger_ptr, prefix, fmt, ...)                                                           \
+        LOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Trace, prefix, fmt, __VA_ARGS__)
+    #define LOG_DIRECT_FMT_DBG(logger_ptr, prefix, fmt, ...)                                                           \
+        LOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Debug, prefix, fmt, __VA_ARGS__)
+    #define LOG_DIRECT_FMT_INF(logger_ptr, prefix, fmt, ...)                                                           \
+        LOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Info, prefix, fmt, __VA_ARGS__)
+    #define LOG_DIRECT_FMT_WRN(logger_ptr, prefix, fmt, ...)                                                           \
+        LOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Warning, prefix, fmt, __VA_ARGS__)
+    #define LOG_DIRECT_FMT_ERR(logger_ptr, prefix, fmt, ...)                                                           \
+        LOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Error, prefix, fmt, __VA_ARGS__)
+    #define LOG_DIRECT_FMT_FAT(logger_ptr, prefix, fmt, ...)                                                           \
+        LOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Fatal, prefix, fmt, __VA_ARGS__)
 
-    #define LOG_DIRECT_STREAM_TRC(logger_ptr) SLOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Trace)
-    #define LOG_DIRECT_STREAM_DBG(logger_ptr) SLOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Debug)
-    #define LOG_DIRECT_STREAM_INF(logger_ptr) SLOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Info)
-    #define LOG_DIRECT_STREAM_WRN(logger_ptr) SLOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Warning)
-    #define LOG_DIRECT_STREAM_ERR(logger_ptr) SLOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Error)
-    #define LOG_DIRECT_STREAM_FAT(logger_ptr) SLOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Fatal)
+    #define LOG_DIRECT_STREAM_TRC(logger_ptr, prefix)                                                                  \
+        SLOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Trace, prefix)
+    #define LOG_DIRECT_STREAM_DBG(logger_ptr, prefix)                                                                  \
+        SLOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Debug, prefix)
+    #define LOG_DIRECT_STREAM_INF(logger_ptr, prefix)                                                                  \
+        SLOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Info, prefix)
+    #define LOG_DIRECT_STREAM_WRN(logger_ptr, prefix)                                                                  \
+        SLOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Warning, prefix)
+    #define LOG_DIRECT_STREAM_ERR(logger_ptr, prefix)                                                                  \
+        SLOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Error, prefix)
+    #define LOG_DIRECT_STREAM_FAT(logger_ptr, prefix)                                                                  \
+        SLOG_DIRECT_FMT(logger_ptr, ::demiplane::scroll::LogLevel::Fatal, prefix)
 #else
-    #define LOG_DIRECT_FMT(logger_ptr, level, fmt, ...) ((void)0)
-    #define SLOG_DIRECT_FMT(logger_ptr, level) ::demiplane::scroll::DummyStream()
+    #define LOG_DIRECT_FMT(logger_ptr, level, prefix, fmt, ...) ((void)0)
+    #define SLOG_DIRECT_FMT(logger_ptr, level, prefix) ::demiplane::scroll::DummyStream()
 
-    #define LOG_DIRECT_FMT_TRC(logger_ptr, fmt, ...) ((void)0)
-    #define LOG_DIRECT_FMT_DBG(logger_ptr, fmt, ...) ((void)0)
-    #define LOG_DIRECT_FMT_INF(logger_ptr, fmt, ...) ((void)0)
-    #define LOG_DIRECT_FMT_WRN(logger_ptr, fmt, ...) ((void)0)
-    #define LOG_DIRECT_FMT_ERR(logger_ptr, fmt, ...) ((void)0)
-    #define LOG_DIRECT_FMT_FAT(logger_ptr, fmt, ...) ((void)0)
+    #define LOG_DIRECT_FMT_TRC(logger_ptr, prefix, fmt, ...) ((void)0)
+    #define LOG_DIRECT_FMT_DBG(logger_ptr, prefix, fmt, ...) ((void)0)
+    #define LOG_DIRECT_FMT_INF(logger_ptr, prefix, fmt, ...) ((void)0)
+    #define LOG_DIRECT_FMT_WRN(logger_ptr, prefix, fmt, ...) ((void)0)
+    #define LOG_DIRECT_FMT_ERR(logger_ptr, prefix, fmt, ...) ((void)0)
+    #define LOG_DIRECT_FMT_FAT(logger_ptr, prefix, fmt, ...) ((void)0)
 
-    #define LOG_DIRECT_STREAM_TRC(logger_ptr) ::demiplane::scroll::DummyStream()
-    #define LOG_DIRECT_STREAM_DBG(logger_ptr) ::demiplane::scroll::DummyStream()
-    #define LOG_DIRECT_STREAM_INF(logger_ptr) ::demiplane::scroll::DummyStream()
-    #define LOG_DIRECT_STREAM_WRN(logger_ptr) ::demiplane::scroll::DummyStream()
-    #define LOG_DIRECT_STREAM_ERR(logger_ptr) ::demiplane::scroll::DummyStream()
-    #define LOG_DIRECT_STREAM_FAT(logger_ptr) ::demiplane::scroll::DummyStream()
+    #define LOG_DIRECT_STREAM_TRC(logger_ptr, prefix) ::demiplane::scroll::DummyStream()
+    #define LOG_DIRECT_STREAM_DBG(logger_ptr, prefix) ::demiplane::scroll::DummyStream()
+    #define LOG_DIRECT_STREAM_INF(logger_ptr, prefix) ::demiplane::scroll::DummyStream()
+    #define LOG_DIRECT_STREAM_WRN(logger_ptr, prefix) ::demiplane::scroll::DummyStream()
+    #define LOG_DIRECT_STREAM_ERR(logger_ptr, prefix) ::demiplane::scroll::DummyStream()
+    #define LOG_DIRECT_STREAM_FAT(logger_ptr, prefix) ::demiplane::scroll::DummyStream()
 #endif
 
+// ============================================================================
+// COMPONENT_LOG_* — prefix sourced from a class-scope `_dmp_scroll_class_prefix`
+// declared by SCROLL_COMPONENT_PREFIX. Usable only inside class member functions.
+// ============================================================================
 #ifdef DMP_COMPONENT_LOGGING
+    #define COMPONENT_LOG_TRC()                                                                                        \
+        LOG_DIRECT_STREAM_TRC(::demiplane::scroll::ComponentLoggerManager::get(), _dmp_scroll_class_prefix.view())
+    #define COMPONENT_LOG_DBG()                                                                                        \
+        LOG_DIRECT_STREAM_DBG(::demiplane::scroll::ComponentLoggerManager::get(), _dmp_scroll_class_prefix.view())
+    #define COMPONENT_LOG_INF()                                                                                        \
+        LOG_DIRECT_STREAM_INF(::demiplane::scroll::ComponentLoggerManager::get(), _dmp_scroll_class_prefix.view())
+    #define COMPONENT_LOG_WRN()                                                                                        \
+        LOG_DIRECT_STREAM_WRN(::demiplane::scroll::ComponentLoggerManager::get(), _dmp_scroll_class_prefix.view())
+    #define COMPONENT_LOG_ERR()                                                                                        \
+        LOG_DIRECT_STREAM_ERR(::demiplane::scroll::ComponentLoggerManager::get(), _dmp_scroll_class_prefix.view())
+    #define COMPONENT_LOG_FAT()                                                                                        \
+        LOG_DIRECT_STREAM_FAT(::demiplane::scroll::ComponentLoggerManager::get(), _dmp_scroll_class_prefix.view())
 
-    // Stream-based logging
-    #define COMPONENT_LOG_TRC() LOG_DIRECT_STREAM_TRC(::demiplane::scroll::ComponentLoggerManager::get())
-    #define COMPONENT_LOG_DBG() LOG_DIRECT_STREAM_DBG(::demiplane::scroll::ComponentLoggerManager::get())
-    #define COMPONENT_LOG_INF() LOG_DIRECT_STREAM_INF(::demiplane::scroll::ComponentLoggerManager::get())
-    #define COMPONENT_LOG_WRN() LOG_DIRECT_STREAM_WRN(::demiplane::scroll::ComponentLoggerManager::get())
-    #define COMPONENT_LOG_ERR() LOG_DIRECT_STREAM_ERR(::demiplane::scroll::ComponentLoggerManager::get())
-    #define COMPONENT_LOG_FAT() LOG_DIRECT_STREAM_FAT(::demiplane::scroll::ComponentLoggerManager::get())
     #define COMPONENT_LOG_ENTER_FUNCTION() COMPONENT_LOG_INF() << "Entering function " << __func__
     #define COMPONENT_LOG_LEAVE_FUNCTION() COMPONENT_LOG_INF() << "Leaving function " << __func__
 
-    // ========== COMPONENT_LOG_*_ONCE (static bool guard) ==========
     #define COMPONENT_LOG_TRC_ONCE()                                                                                   \
         if (SCROLL_ONCE_GUARD_)                                                                                        \
         COMPONENT_LOG_TRC()
-    #define COMPONENT_LOG_DBG_ONCE() if (SCROLL_ONCE_GUARD_) COMPONENT_LOG_DBG()
-    #define COMPONENT_LOG_INF_ONCE() if (SCROLL_ONCE_GUARD_) COMPONENT_LOG_INF()
-    #define COMPONENT_LOG_WRN_ONCE() if (SCROLL_ONCE_GUARD_) COMPONENT_LOG_WRN()
-    #define COMPONENT_LOG_ERR_ONCE() if (SCROLL_ONCE_GUARD_) COMPONENT_LOG_ERR()
-    #define COMPONENT_LOG_FAT_ONCE() if (SCROLL_ONCE_GUARD_) COMPONENT_LOG_FAT()
+    #define COMPONENT_LOG_DBG_ONCE()                                                                                   \
+        if (SCROLL_ONCE_GUARD_)                                                                                        \
+        COMPONENT_LOG_DBG()
+    #define COMPONENT_LOG_INF_ONCE()                                                                                   \
+        if (SCROLL_ONCE_GUARD_)                                                                                        \
+        COMPONENT_LOG_INF()
+    #define COMPONENT_LOG_WRN_ONCE()                                                                                   \
+        if (SCROLL_ONCE_GUARD_)                                                                                        \
+        COMPONENT_LOG_WRN()
+    #define COMPONENT_LOG_ERR_ONCE()                                                                                   \
+        if (SCROLL_ONCE_GUARD_)                                                                                        \
+        COMPONENT_LOG_ERR()
+    #define COMPONENT_LOG_FAT_ONCE()                                                                                   \
+        if (SCROLL_ONCE_GUARD_)                                                                                        \
+        COMPONENT_LOG_FAT()
 
-    // ========== COMPONENT_LOG_*_ATOMIC_ONCE (std::atomic<bool> guard) ==========
-    #define COMPONENT_LOG_TRC_ATOMIC_ONCE() if (SCROLL_ATOMIC_ONCE_GUARD_) COMPONENT_LOG_TRC()
-    #define COMPONENT_LOG_DBG_ATOMIC_ONCE() if (SCROLL_ATOMIC_ONCE_GUARD_) COMPONENT_LOG_DBG()
-    #define COMPONENT_LOG_INF_ATOMIC_ONCE() if (SCROLL_ATOMIC_ONCE_GUARD_) COMPONENT_LOG_INF()
-    #define COMPONENT_LOG_WRN_ATOMIC_ONCE() if (SCROLL_ATOMIC_ONCE_GUARD_) COMPONENT_LOG_WRN()
-    #define COMPONENT_LOG_ERR_ATOMIC_ONCE() if (SCROLL_ATOMIC_ONCE_GUARD_) COMPONENT_LOG_ERR()
-    #define COMPONENT_LOG_FAT_ATOMIC_ONCE() if (SCROLL_ATOMIC_ONCE_GUARD_) COMPONENT_LOG_FAT()
+    #define COMPONENT_LOG_TRC_ATOMIC_ONCE()                                                                            \
+        if (SCROLL_ATOMIC_ONCE_GUARD_)                                                                                 \
+        COMPONENT_LOG_TRC()
+    #define COMPONENT_LOG_DBG_ATOMIC_ONCE()                                                                            \
+        if (SCROLL_ATOMIC_ONCE_GUARD_)                                                                                 \
+        COMPONENT_LOG_DBG()
+    #define COMPONENT_LOG_INF_ATOMIC_ONCE()                                                                            \
+        if (SCROLL_ATOMIC_ONCE_GUARD_)                                                                                 \
+        COMPONENT_LOG_INF()
+    #define COMPONENT_LOG_WRN_ATOMIC_ONCE()                                                                            \
+        if (SCROLL_ATOMIC_ONCE_GUARD_)                                                                                 \
+        COMPONENT_LOG_WRN()
+    #define COMPONENT_LOG_ERR_ATOMIC_ONCE()                                                                            \
+        if (SCROLL_ATOMIC_ONCE_GUARD_)                                                                                 \
+        COMPONENT_LOG_ERR()
+    #define COMPONENT_LOG_FAT_ATOMIC_ONCE()                                                                            \
+        if (SCROLL_ATOMIC_ONCE_GUARD_)                                                                                 \
+        COMPONENT_LOG_FAT()
 #else
-    // When component logging is disabled, use scroll's dummy implementations
     #define COMPONENT_LOG(level, message) ((void)0)
     #define COMPONENT_LOG_TRC() ::demiplane::scroll::DummyStream()
     #define COMPONENT_LOG_DBG() ::demiplane::scroll::DummyStream()

--- a/common/scroll/provider/include/log_macros.hpp
+++ b/common/scroll/provider/include/log_macros.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <string_view>
-
 #include <gears_macros.hpp>
-#include <gears_strings.hpp>
 
 namespace demiplane::scroll {
     // Dummy stream for disabled logging
@@ -30,8 +27,8 @@ namespace demiplane::scroll {
 // consteval-throw path in InlineString::assign → compile error.
 // ============================================================================
 #define SCROLL_COMPONENT_PREFIX(name)                                                                                  \
-    static constexpr ::demiplane::gears::InlineString<31> _dmp_scroll_class_prefix = [] {                              \
-        ::demiplane::gears::InlineString<31> s;                                                                        \
+    static constexpr ::demiplane::scroll::PrefixNameStorage _dmp_scroll_class_prefix = [] {                            \
+        ::demiplane::scroll::PrefixNameStorage s;                                                                      \
         s.assign(::std::string_view{name});                                                                            \
         return s;                                                                                                      \
     }()

--- a/common/scroll/provider/include/logger_provider.hpp
+++ b/common/scroll/provider/include/logger_provider.hpp
@@ -3,8 +3,6 @@
 #include <memory>
 #include <string_view>
 
-#include <gears_strings.hpp>
-
 #include "console_sink.hpp"
 #include "detailed_entry.hpp"
 #include "file_sink.hpp"
@@ -18,6 +16,11 @@ namespace demiplane::scroll {
      *
      * The @p prefix_ is a class-name / subsystem label rendered into log output
      * and usable by per-sink `PrefixFilter` for allow/deny routing.
+     *
+     * Prefix overflow: values longer than `PrefixNameStorage` capacity are
+     * silently truncated at runtime (see `PrefixNameStorage` docs). Prefer
+     * `SCROLL_COMPONENT_PREFIX` for literal names — it catches overflow at
+     * compile time.
      *
      * Thread safety: @ref set_prefix is NOT thread-safe. Callers must set the
      * prefix during construction before the object is visible to other threads.
@@ -47,7 +50,7 @@ namespace demiplane::scroll {
             return logger_.get();
         }
 
-        [[nodiscard]] constexpr const gears::InlineString<31>& prefix() const noexcept {
+        [[nodiscard]] constexpr const PrefixNameStorage& prefix() const noexcept {
             return prefix_;
         }
 
@@ -56,13 +59,14 @@ namespace demiplane::scroll {
         }
 
         /// @note NOT thread-safe — see class docs.
+        /// @note Oversized @p prefix is silently truncated at runtime.
         constexpr void set_prefix(const std::string_view prefix) noexcept {
             prefix_.assign(prefix);
         }
 
     private:
         std::shared_ptr<Logger> logger_;
-        gears::InlineString<31> prefix_;
+        PrefixNameStorage prefix_;
     };
 
     /**

--- a/common/scroll/provider/include/logger_provider.hpp
+++ b/common/scroll/provider/include/logger_provider.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
+
+#include <gears_strings.hpp>
 
 #include "console_sink.hpp"
 #include "detailed_entry.hpp"
@@ -12,6 +15,13 @@ namespace demiplane::scroll {
      * @brief Logger provider - wraps logger instance
      *
      * Allows dependency injection and testing.
+     *
+     * The @p prefix_ is a class-name / subsystem label rendered into log output
+     * and usable by per-sink `PrefixFilter` for allow/deny routing.
+     *
+     * Thread safety: @ref set_prefix is NOT thread-safe. Callers must set the
+     * prefix during construction before the object is visible to other threads.
+     * Concurrent `set_prefix` with active logging is UB (data race).
      */
     class LoggerProvider {
     public:
@@ -19,8 +29,14 @@ namespace demiplane::scroll {
 
         LoggerProvider() = default;
 
-        explicit LoggerProvider(std::shared_ptr<Logger> logger)
+        // Single 2-arg constructor with default prefix — the 1-arg
+        // `LoggerProvider{logger}` form stays valid (prefix defaults empty).
+        // `explicit` prevents implicit conversion from `shared_ptr<Logger>`
+        // alone and avoids ambiguous overload resolution we'd hit if we
+        // also declared a separate 1-arg constructor.
+        constexpr explicit LoggerProvider(std::shared_ptr<Logger> logger, const std::string_view prefix = {})
             : logger_{std::move(logger)} {
+            prefix_.assign(prefix);
         }
 
         [[nodiscard]] Logger* get_logger() noexcept {
@@ -31,12 +47,22 @@ namespace demiplane::scroll {
             return logger_.get();
         }
 
+        [[nodiscard]] constexpr const gears::InlineString<31>& prefix() const noexcept {
+            return prefix_;
+        }
+
         void set_logger(std::shared_ptr<Logger> logger) noexcept {
             logger_ = std::move(logger);
         }
 
+        /// @note NOT thread-safe — see class docs.
+        constexpr void set_prefix(const std::string_view prefix) noexcept {
+            prefix_.assign(prefix);
+        }
+
     private:
         std::shared_ptr<Logger> logger_;
+        gears::InlineString<31> prefix_;
     };
 
     /**
@@ -69,12 +95,10 @@ namespace demiplane::scroll {
 
     /**
      * @brief Test logger provider with console output
-     *
-     * Convenience for testing - creates logger with console sink that flushes each entry.
      */
     class TestLoggerProvider : public LoggerProvider {
     public:
-        explicit TestLoggerProvider() {
+        constexpr explicit TestLoggerProvider(const std::string_view prefix = {}) {
             auto logger = std::make_shared<Logger>();
             logger->add_sink(std::make_shared<ConsoleSink<DetailedEntry>>(ConsoleSinkConfig::Builder{}
                                                                               .threshold(LogLevel::Debug)
@@ -82,6 +106,9 @@ namespace demiplane::scroll {
                                                                               .flush_each_entry(true)
                                                                               .finalize()));
             set_logger(std::move(logger));
+            set_prefix(prefix);
         }
     };
+
+    // todo: possibly make default file sink logger
 }  // namespace demiplane::scroll

--- a/common/scroll/sink/console_sink/include/console_sink.hpp
+++ b/common/scroll/sink/console_sink/include/console_sink.hpp
@@ -38,11 +38,10 @@ namespace demiplane::scroll {
         }
 
         void process(const LogEvent& event) override {
-            if (!should_log(event.level)) {
+            if (!should_log(event.level, event.prefix.view())) {
                 return;
             }
 
-            // Convert LogEvent → EntryType using existing factory pattern
             auto entry = make_entry_from_event<EntryType>(event);
             entry.format_into(format_buffer_);
 
@@ -64,8 +63,9 @@ namespace demiplane::scroll {
             config_.output()->flush();
         }
 
-        [[nodiscard]] bool should_log(LogLevel lvl) const noexcept override {
-            return static_cast<int8_t>(lvl) >= static_cast<int8_t>(config_.threshold());
+        [[nodiscard]] bool should_log(LogLevel lvl, const std::string_view prefix) const noexcept override {
+            return static_cast<int8_t>(lvl) >= static_cast<int8_t>(config_.threshold()) &&
+                   config_.prefix_filter().accepts(prefix);
         }
 
         // Allow runtime config replacement

--- a/common/scroll/sink/console_sink/include/console_sink_config.hpp
+++ b/common/scroll/sink/console_sink/include/console_sink_config.hpp
@@ -4,6 +4,7 @@
 
 #include <config_interface.hpp>
 #include <json/json.hpp>
+#include <prefix_filter.hpp>
 #include <sink_interface.hpp>
 
 namespace demiplane::scroll {
@@ -14,11 +15,13 @@ namespace demiplane::scroll {
         constexpr ConsoleSinkConfig(const LogLevel threshold,
                                     const bool enable_colors,
                                     const bool flush_each_entry,
-                                    std::ostream* const output) noexcept
+                                    std::ostream* const output,
+                                    PrefixFilter prefix_filter = {}) noexcept
             : threshold_{threshold},
               enable_colors_{enable_colors},
               flush_each_entry_{flush_each_entry},
-              output_{output} {
+              output_{output},
+              prefix_filter_{std::move(prefix_filter)} {
         }
 
         constexpr void validate() const override {
@@ -37,6 +40,9 @@ namespace demiplane::scroll {
         [[nodiscard]] constexpr std::ostream* output() const noexcept {
             return output_;
         }
+        [[nodiscard]] constexpr const PrefixFilter& prefix_filter() const noexcept {
+            return prefix_filter_;
+        }
 
         static constexpr auto fields() {
             return std::tuple{
@@ -44,6 +50,8 @@ namespace demiplane::scroll {
                 serialization::Field<&ConsoleSinkConfig::enable_colors_, "enable_colors">{},
                 serialization::Field<&ConsoleSinkConfig::flush_each_entry_, "flush_each_entry">{},
                 serialization::Field<&ConsoleSinkConfig::output_, "output", serialization::FieldPolicy::Excluded>{},
+                serialization::
+                    Field<&ConsoleSinkConfig::prefix_filter_, "prefix_filter", serialization::FieldPolicy::Excluded>{},
             };
         }
 
@@ -57,6 +65,7 @@ namespace demiplane::scroll {
         bool enable_colors_    = true;
         bool flush_each_entry_ = false;
         std::ostream* output_  = &std::cout;
+        PrefixFilter prefix_filter_{};
     };
 
     class ConsoleSinkConfig::Builder {
@@ -90,6 +99,12 @@ namespace demiplane::scroll {
         template <typename Self>
         constexpr auto&& output(this Self&& self, std::ostream* value) noexcept {
             self.config_.output_ = value;
+            return std::forward<Self>(self);
+        }
+
+        template <typename Self>
+        constexpr auto&& prefix_filter(this Self&& self, PrefixFilter value) noexcept {
+            self.config_.prefix_filter_ = std::move(value);
             return std::forward<Self>(self);
         }
 

--- a/common/scroll/sink/file_sink/include/file_sink.hpp
+++ b/common/scroll/sink/file_sink/include/file_sink.hpp
@@ -44,13 +44,10 @@ namespace demiplane::scroll {
         }
 
         void process(const LogEvent& event) override {
-            if (!should_log(event.level)) {
+            if (!should_log(event.level, event.prefix.view())) {
                 return;
             }
 
-            // Convert LogEvent → EntryType using existing factory pattern
-
-            // Lock only for the actual write (supports multiple loggers sharing this sink)
             {
                 auto entry = make_entry_from_event<EntryType>(event);
                 entry.format_into(format_buffer_);
@@ -62,7 +59,6 @@ namespace demiplane::scroll {
                 }
             }
 
-            // Check if rotation needed (outside lock to minimize contention)
             if (should_rotate()) {
                 rotate_log();
             }
@@ -73,8 +69,9 @@ namespace demiplane::scroll {
             file_stream_.flush();
         }
 
-        [[nodiscard]] bool should_log(LogLevel lvl) const noexcept override {
-            return static_cast<int8_t>(lvl) >= static_cast<int8_t>(config_.threshold());
+        [[nodiscard]] bool should_log(LogLevel lvl, const std::string_view prefix) const noexcept override {
+            return static_cast<int8_t>(lvl) >= static_cast<int8_t>(config_.threshold()) &&
+                   config_.prefix_filter().accepts(prefix);
         }
 
         void set_config(FileSinkConfig cfg) noexcept {

--- a/common/scroll/sink/file_sink/include/file_sink_config.hpp
+++ b/common/scroll/sink/file_sink/include/file_sink_config.hpp
@@ -6,6 +6,7 @@
 
 #include <config_interface.hpp>
 #include <json/json.hpp>
+#include <prefix_filter.hpp>
 #include <sink_interface.hpp>
 
 namespace demiplane::scroll {
@@ -19,14 +20,16 @@ namespace demiplane::scroll {
                                  std::string time_format_in_file_name,
                                  const bool rotate_file,
                                  const std::uint64_t max_file_size,
-                                 const bool flush_each_entry) noexcept
+                                 const bool flush_each_entry,
+                                 PrefixFilter prefix_filter = {}) noexcept
             : threshold_{threshold},
               file_{std::move(file)},
               add_time_to_filename_{add_time_to_filename},
               time_format_in_file_name_{std::move(time_format_in_file_name)},
               rotate_file_{rotate_file},
               max_file_size_{max_file_size},
-              flush_each_entry_{flush_each_entry} {
+              flush_each_entry_{flush_each_entry},
+              prefix_filter_{std::move(prefix_filter)} {
         }
 
         constexpr void validate() const override {
@@ -65,6 +68,9 @@ namespace demiplane::scroll {
         [[nodiscard]] constexpr bool rotate_file() const noexcept {
             return rotate_file_;
         }
+        [[nodiscard]] const PrefixFilter& prefix_filter() const noexcept {
+            return prefix_filter_;
+        }
 
         static constexpr auto fields() {
             return std::tuple{
@@ -75,6 +81,8 @@ namespace demiplane::scroll {
                 serialization::Field<&FileSinkConfig::rotate_file_, "rotate_file">{},
                 serialization::Field<&FileSinkConfig::max_file_size_, "max_file_size">{},
                 serialization::Field<&FileSinkConfig::flush_each_entry_, "flush_each_entry">{},
+                serialization::
+                    Field<&FileSinkConfig::prefix_filter_, "prefix_filter", serialization::FieldPolicy::Excluded>{},
             };
         }
 
@@ -92,6 +100,7 @@ namespace demiplane::scroll {
         bool rotate_file_            = true;
         std::uint64_t max_file_size_ = gears::literals::operator""_mb(100);
         bool flush_each_entry_       = false;
+        PrefixFilter prefix_filter_{};
     };
 
     class FileSinkConfig::Builder {
@@ -143,6 +152,12 @@ namespace demiplane::scroll {
         template <typename Self>
         constexpr auto&& rotation(this Self&& self, const bool value) noexcept {
             self.config_.rotate_file_ = value;
+            return std::forward<Self>(self);
+        }
+
+        template <typename Self>
+        constexpr auto&& prefix_filter(this Self&& self, PrefixFilter value) noexcept {
+            self.config_.prefix_filter_ = std::move(value);
             return std::forward<Self>(self);
         }
 

--- a/common/scroll/sink/interface/log_event.hpp
+++ b/common/scroll/sink/interface/log_event.hpp
@@ -3,7 +3,6 @@
 #include <string>
 
 #include <entry_interface.hpp>
-#include <gears_strings.hpp>  // for gears::InlineString
 
 namespace demiplane::scroll {
     /**
@@ -17,8 +16,8 @@ namespace demiplane::scroll {
     struct LogEvent {
         // Core data
         LogLevel level = LogLevel::Debug;
-        gears::InlineString<31> prefix{};  // owning class-name/prefix; empty if none
-        std::string message;               // Already formatted with std::format or stream
+        PrefixNameStorage prefix{};  // owning class-name/prefix; empty if none
+        std::string message;         // Already formatted with std::format or stream
 
         // Metadata (captured in producer thread - correct TID/PID)
         detail::MetaSource location;

--- a/common/scroll/sink/interface/log_event.hpp
+++ b/common/scroll/sink/interface/log_event.hpp
@@ -3,6 +3,7 @@
 #include <string>
 
 #include <entry_interface.hpp>
+#include <gears_strings.hpp>  // for gears::InlineString
 
 namespace demiplane::scroll {
     /**
@@ -16,7 +17,8 @@ namespace demiplane::scroll {
     struct LogEvent {
         // Core data
         LogLevel level = LogLevel::Debug;
-        std::string message;  // Already formatted with std::format or stream
+        gears::InlineString<31> prefix{};  // owning class-name/prefix; empty if none
+        std::string message;               // Already formatted with std::format or stream
 
         // Metadata (captured in producer thread - correct TID/PID)
         detail::MetaSource location;
@@ -47,7 +49,8 @@ namespace demiplane::scroll {
     template <class EntryT>
     EntryT make_entry_from_event(const LogEvent& event) {
         // Build tuple with all available metadata from LogEvent
-        auto available = std::tuple{event.time_point, event.location, event.tid, event.pid};
+        auto available =
+            std::tuple{event.time_point, event.location, event.tid, event.pid, detail::MetaPrefix{event.prefix.view()}};
 
         // Use entry_traits to extract only what EntryT wants
         using want_types = detail::entry_traits<EntryT>::wants;

--- a/common/scroll/sink/interface/prefix_filter.hpp
+++ b/common/scroll/sink/interface/prefix_filter.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+
+namespace demiplane::scroll {
+
+    /// Transparent hash so `unordered_set<std::string, PrefixHash, std::equal_to<>>`
+    /// supports `contains(string_view)` without constructing a temporary std::string.
+    struct PrefixHash {
+        using is_transparent = void;
+
+        std::size_t operator()(std::string_view sv) const noexcept {
+            return std::hash<std::string_view>{}(sv);
+        }
+        std::size_t operator()(const std::string& s) const noexcept {
+            return std::hash<std::string_view>{}(s);
+        }
+    };
+
+    enum class PrefixFilterMode : std::uint8_t { AllowAll, Allowlist, Denylist };
+
+    /**
+     * @brief Per-sink prefix allow / deny filter.
+     *
+     * Mutually exclusive modes. Empty prefix is accepted by default in all modes;
+     * call @ref block_empty_prefix to reject it.
+     */
+    class PrefixFilter {
+    public:
+        using Set = std::unordered_set<std::string, PrefixHash, std::equal_to<>>;
+
+        constexpr PrefixFilter() = default;  // AllowAll
+
+        [[nodiscard]] constexpr static PrefixFilter allow(Set set) {
+            return PrefixFilter{PrefixFilterMode::Allowlist, std::move(set)};
+        }
+        [[nodiscard]] constexpr static PrefixFilter deny(Set set) {
+            return PrefixFilter{PrefixFilterMode::Denylist, std::move(set)};
+        }
+
+        constexpr PrefixFilter& block_empty_prefix() noexcept {
+            block_empty_ = true;
+            return *this;
+        }
+
+        [[nodiscard]] constexpr bool accepts(const std::string_view prefix) const noexcept {
+            if (prefix.empty()) {
+                return !block_empty_;
+            }
+            switch (mode_) {
+                case PrefixFilterMode::AllowAll:
+                    return true;
+                case PrefixFilterMode::Allowlist:
+                    return set_.contains(prefix);
+                case PrefixFilterMode::Denylist:
+                    return !set_.contains(prefix);
+            }
+            return true;  // unreachable — defensive default
+        }
+
+        [[nodiscard]] constexpr PrefixFilterMode mode() const noexcept {
+            return mode_;
+        }
+        [[nodiscard]] constexpr bool blocks_empty() const noexcept {
+            return block_empty_;
+        }
+
+    private:
+        constexpr PrefixFilter(const PrefixFilterMode m, Set s)
+            : mode_{m},
+              set_{std::move(s)} {
+        }
+
+        PrefixFilterMode mode_ = PrefixFilterMode::AllowAll;
+        bool block_empty_      = false;
+        Set set_;
+    };
+
+}  // namespace demiplane::scroll

--- a/common/scroll/sink/interface/prefix_filter.hpp
+++ b/common/scroll/sink/interface/prefix_filter.hpp
@@ -60,7 +60,7 @@ namespace demiplane::scroll {
                 case PrefixFilterMode::Denylist:
                     return !set_.contains(prefix);
             }
-            return true;  // unreachable — defensive default
+            std::unreachable();
         }
 
         [[nodiscard]] constexpr PrefixFilterMode mode() const noexcept {

--- a/common/scroll/sink/interface/sink_interface.hpp
+++ b/common/scroll/sink/interface/sink_interface.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
 #include <vector>
 
 #include "log_event.hpp"
@@ -54,10 +55,11 @@ namespace demiplane::scroll {
         /**
          * @brief Check if this sink should process this log level
          * @param lvl Log level to check
+         * @param prefix Prefix of the message to check
          * @return true if sink will process this level
          *
          * Used for early filtering before calling process().
          */
-        [[nodiscard]] virtual bool should_log(LogLevel lvl) const noexcept = 0;
+        [[nodiscard]] virtual bool should_log(LogLevel lvl, std::string_view prefix) const noexcept = 0;
     };
 }  // namespace demiplane::scroll

--- a/components/database/base/errors/db_error_codes.hpp
+++ b/components/database/base/errors/db_error_codes.hpp
@@ -168,7 +168,7 @@ namespace demiplane::db {
         /**
          * @brief Construct from fatal error code
          */
-        explicit constexpr ErrorCode(FatalErrorCode code) noexcept
+        constexpr explicit ErrorCode(FatalErrorCode code) noexcept
             : category_(Category::Fatal),
               code_(static_cast<uint16_t>(code)) {
         }

--- a/components/database/primitives/table/db_static_table.hpp
+++ b/components/database/primitives/table/db_static_table.hpp
@@ -31,7 +31,7 @@ namespace demiplane::db {
     public:
         static constexpr std::size_t N = sizeof...(FieldSchemas);
 
-        [[nodiscard]] explicit constexpr StaticTable(const Providers provider = Providers::None) noexcept
+        [[nodiscard]] constexpr explicit StaticTable(const Providers provider = Providers::None) noexcept
             : provider_{provider} {
         }
 

--- a/components/database/providers/postgresql/capabilities/executors/async_executor/postgres_async_executor.hpp
+++ b/components/database/providers/postgresql/capabilities/executors/async_executor/postgres_async_executor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <demiplane/scroll>
 #include <memory>
 #include <utility>
 
@@ -180,6 +181,8 @@ namespace demiplane::db::postgres {
         }
 
     private:
+        SCROLL_COMPONENT_PREFIX("AsyncExecutor");
+
         PGconn* conn_ = nullptr;
         boost::asio::any_io_executor executor_;
         std::unique_ptr<boost::asio::posix::stream_descriptor> socket_;

--- a/components/database/providers/postgresql/capabilities/executors/sync_executor/postgres_sync_executor.hpp
+++ b/components/database/providers/postgresql/capabilities/executors/sync_executor/postgres_sync_executor.hpp
@@ -164,11 +164,13 @@ namespace demiplane::db::postgres {
         }
 
     private:
-        [[nodiscard]] gears::Outcome<ResultBlock, ErrorContext> execute_impl(const char* query,
-                                                                             const Params* params) const;
+        SCROLL_COMPONENT_PREFIX("SyncExecutor");
 
         PGconn* conn_ = nullptr;
         std::weak_ptr<ConnectionHolder> holder_;
+
+        [[nodiscard]] gears::Outcome<ResultBlock, ErrorContext> execute_impl(const char* query,
+                                                                             const Params* params) const;
     };
 
     static_assert(IsExecutor<SyncExecutor>);

--- a/components/database/providers/postgresql/config/postgres_connection_config.hpp
+++ b/components/database/providers/postgresql/config/postgres_connection_config.hpp
@@ -43,7 +43,7 @@ namespace demiplane::db::postgres {
      */
     class ConnectionConfig final : public serialization::ConfigInterface<ConnectionConfig, Json::Value> {
     public:
-        explicit constexpr ConnectionConfig(ConnectionCredentials credentials) noexcept
+        constexpr explicit ConnectionConfig(ConnectionCredentials credentials) noexcept
             : credentials_{std::move(credentials)} {
         }
 

--- a/components/database/providers/postgresql/session/blocking/postgres_blocking_session.hpp
+++ b/components/database/providers/postgresql/session/blocking/postgres_blocking_session.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <demiplane/scroll>
 
 #include <boost/asio/awaitable.hpp>
 #include <capability_provider.hpp>
@@ -75,6 +76,8 @@ namespace demiplane::db::postgres {
         [[nodiscard]] bool is_shutdown() const noexcept;
 
     private:
+        SCROLL_COMPONENT_PREFIX("BlockingSession");
+
         BlockingPool pool_;
     };
 

--- a/components/database/providers/postgresql/session/free_lock/postgres_free_lock_session.hpp
+++ b/components/database/providers/postgresql/session/free_lock/postgres_free_lock_session.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <demiplane/scroll>
 
 #include <capability_provider.hpp>
 #include <gears_class_traits.hpp>
@@ -110,6 +111,8 @@ namespace demiplane::db::postgres {
         [[nodiscard]] bool is_shutdown() const noexcept;
 
     private:
+        SCROLL_COMPONENT_PREFIX("LockFreeSession");
+
         ConnectionPool pool_;
         PoolJanitor janitor_;
     };

--- a/components/database/providers/postgresql/transaction/base/transaction.hpp
+++ b/components/database/providers/postgresql/transaction/base/transaction.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <demiplane/scroll>
 #include <memory>
 
 #include <capability_provider.hpp>
@@ -72,14 +73,17 @@ namespace demiplane::db::postgres {
     private:
         friend class LockFreeSession;
         friend class BlockingSession;
-        Transaction(std::weak_ptr<ConnectionHolder> holder, TransactionOptions opts);
 
-        [[nodiscard]] gears::Outcome<void, ErrorContext> execute_control(const std::string& sql) const;
+        SCROLL_COMPONENT_PREFIX("Transaction");
 
         std::weak_ptr<ConnectionHolder> holder_;
         PGconn* conn_ = nullptr;
         TransactionOptions options_;
         TransactionStatus status_ = TransactionStatus::IDLE;
+
+        Transaction(std::weak_ptr<ConnectionHolder> holder, TransactionOptions opts);
+
+        [[nodiscard]] gears::Outcome<void, ErrorContext> execute_control(const std::string& sql) const;
     };
 
     static_assert(CapabilityProvider<Transaction>);

--- a/components/database/providers/postgresql/transaction/savepoint/savepoint.hpp
+++ b/components/database/providers/postgresql/transaction/savepoint/savepoint.hpp
@@ -29,17 +29,21 @@ namespace demiplane::db::postgres {
 
     private:
         friend class Transaction;
-        Savepoint(PGconn* conn, std::string name)
-            : conn_{conn},
-              name_{std::move(name)} {
-            COMPONENT_LOG_INF() << "Savepoint '" << name_ << "' created";
-        }
 
-        [[nodiscard]] gears::Outcome<void, ErrorContext> execute_control(const std::string& sql) const;
+        SCROLL_COMPONENT_PREFIX("Savepoint");
 
         PGconn* conn_;
         std::string name_;
         bool active_ = true;
+
+        template <gears::IsStringLike StringTp>
+        constexpr Savepoint(PGconn* conn, StringTp&& name)
+            : conn_{conn},
+              name_{std::forward<StringTp>(name)} {
+            COMPONENT_LOG_INF() << "Savepoint '" << name_ << "' created";
+        }
+
+        [[nodiscard]] gears::Outcome<void, ErrorContext> execute_control(const std::string& sql) const;
     };
 
 }  // namespace demiplane::db::postgres

--- a/components/database/query/compiler/query_compiler.hpp
+++ b/components/database/query/compiler/query_compiler.hpp
@@ -83,5 +83,8 @@ namespace demiplane::db {
             }
             std::unreachable();
         }
+
+    private:
+        SCROLL_COMPONENT_PREFIX("QueryCompiler");
     };
 }  // namespace demiplane::db

--- a/components/http/CMakeLists.txt
+++ b/components/http/CMakeLists.txt
@@ -40,7 +40,6 @@ target_link_libraries(${DMP_HTTP}.Handler
         Boost::asio
         JsonCpp::JsonCpp
         Demiplane::Common::Nexus
-        PRIVATE
         Demiplane::Common::Scroll
 )
 ##############################################################################

--- a/components/http/http_server/include/controller.hpp
+++ b/components/http/http_server/include/controller.hpp
@@ -2,6 +2,7 @@
 
 #include <demiplane/gears>
 #include <demiplane/nexus>
+#include <demiplane/scroll>
 #include <memory>
 
 #include "aliases.hpp"
@@ -143,6 +144,8 @@ namespace demiplane::http {
         }
 
     private:
+        SCROLL_COMPONENT_PREFIX("HttpController");
+
         RouteRegistry registry_;
 
         // Binding helpers for member functions

--- a/components/http/http_server/include/route_registry.hpp
+++ b/components/http/http_server/include/route_registry.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <demiplane/nexus>
+#include <demiplane/scroll>
 #include <memory>
 #include <regex>
 #include <string>
@@ -48,6 +49,8 @@ namespace demiplane::http {
         RouteRegistry& operator=(const RouteRegistry& other);
 
     private:
+        SCROLL_COMPONENT_PREFIX("RouteRegistry");
+
         boost::unordered::unordered_flat_map<std::string, ContextHandler> exact_routes_;
         std::vector<RouteInfo> parametric_routes_;
 

--- a/components/http/http_server/include/server.hpp
+++ b/components/http/http_server/include/server.hpp
@@ -3,6 +3,7 @@
 
 #include <atomic>
 #include <demiplane/nexus>
+#include <demiplane/scroll>
 #include <memory>
 #include <vector>
 
@@ -49,6 +50,8 @@ namespace demiplane::http {
         void stop();
 
     private:
+        SCROLL_COMPONENT_PREFIX("Server");
+
         mutable boost::asio::io_context ioc_;
         std::size_t thread_count_;
         RouteRegistry registry_;  // Single registry for all routes

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -56,6 +56,8 @@ add_unit_test(${UNIT_TESTING_TARGET}.Scroll
         scroll/logger/file_sink_test.cpp
         scroll/logger/console_sink_test.cpp
         scroll/logger/logger_ordering_test.cpp
+        scroll/prefix_filter_test.cpp
+        scroll/prefix_integration_test.cpp
 )
 target_link_libraries(${UNIT_TESTING_TARGET}.Scroll
         PRIVATE
@@ -98,6 +100,19 @@ add_unit_test(${UNIT_TESTING_TARGET}.Gears.Result.Outcome
         gears/test_outcome.cpp
 )
 target_link_libraries(${UNIT_TESTING_TARGET}.Gears.Result.Outcome
+        PRIVATE
+        Demiplane::Common::Gears
+        ${TEST_LIBS}
+)
+##############################################################################
+
+##############################################################################
+# Test Gears InlineString
+##############################################################################
+add_unit_test(${UNIT_TESTING_TARGET}.Gears.Strings.InlineString
+        gears/test_inline_string.cpp
+)
+target_link_libraries(${UNIT_TESTING_TARGET}.Gears.Strings.InlineString
         PRIVATE
         Demiplane::Common::Gears
         ${TEST_LIBS}

--- a/tests/unit_tests/gears/test_inline_string.cpp
+++ b/tests/unit_tests/gears/test_inline_string.cpp
@@ -1,0 +1,85 @@
+#include <gears_strings.hpp>
+#include <gtest/gtest.h>
+
+using demiplane::gears::InlineString;
+
+TEST(InlineStringTest, AssignStoresExactString) {
+    InlineString<31> s;
+    s.assign(std::string_view{"hello"});
+    EXPECT_EQ(s.view(), "hello");
+    EXPECT_EQ(s.size(), 5u);
+    EXPECT_STREQ(s.c_str(), "hello");
+}
+
+TEST(InlineStringTest, AssignTruncatesOverflowAtRuntime) {
+    InlineString<4> s;
+    s.assign(std::string_view{"too long for four"});
+    EXPECT_EQ(s.view(), "too ");
+    EXPECT_EQ(s.size(), 4u);
+    EXPECT_STREQ(s.c_str(), "too ");
+}
+
+TEST(InlineStringTest, AssignOverwritesPrior) {
+    InlineString<31> s;
+    s.assign(std::string_view{"first"});
+    s.assign(std::string_view{"second longer"});
+    EXPECT_EQ(s.view(), "second longer");
+    EXPECT_EQ(s.size(), 13u);
+}
+
+TEST(InlineStringTest, AssignEmptyClears) {
+    InlineString<31> s;
+    s.assign(std::string_view{"nonempty"});
+    s.assign(std::string_view{});
+    EXPECT_TRUE(s.empty());
+    EXPECT_EQ(s.size(), 0u);
+    EXPECT_STREQ(s.c_str(), "");
+}
+
+TEST(InlineStringTest, ClearResetsToEmpty) {
+    InlineString<31> s;
+    s.assign(std::string_view{"content"});
+    s.clear();
+    EXPECT_TRUE(s.empty());
+    EXPECT_EQ(s.size(), 0u);
+    EXPECT_STREQ(s.c_str(), "");
+}
+
+TEST(InlineStringTest, ClearIsIdempotent) {
+    InlineString<31> s;
+    s.clear();
+    EXPECT_TRUE(s.empty());
+    EXPECT_STREQ(s.c_str(), "");
+
+    s.assign(std::string_view{"payload"});
+    s.clear();
+    s.clear();
+    EXPECT_TRUE(s.empty());
+    EXPECT_EQ(s.size(), 0u);
+    EXPECT_STREQ(s.c_str(), "");
+}
+
+TEST(InlineStringTest, AssignAtCompileTimeFitting) {
+    constexpr auto s = [] {
+        InlineString<31> x;
+        x.assign(std::string_view{"Compile"});
+        return x;
+    }();
+    static_assert(s.view() == std::string_view{"Compile"});
+    static_assert(s.size() == 7u);
+    EXPECT_EQ(s.view(), "Compile");
+}
+
+// Compile-time overflow demo (intentionally NOT compiled — switching to 1 would fail to build):
+// constexpr auto fails = [] {
+//     InlineString<2> x;
+//     x.assign(std::string_view{"three"});   // triggers throw at consteval → compile error
+//     return x;
+// }();
+
+TEST(InlineStringTest, AssignExactlyCapacityFitsWithoutTruncation) {
+    InlineString<5> s;
+    s.assign(std::string_view{"hello"});
+    EXPECT_EQ(s.view(), "hello");
+    EXPECT_EQ(s.size(), 5u);
+}

--- a/tests/unit_tests/scroll/entry_tests.cpp
+++ b/tests/unit_tests/scroll/entry_tests.cpp
@@ -104,3 +104,41 @@ TEST(TestEntries, MakeEntryFromEvent) {
     EXPECT_TRUE(light_output.find("Test message from event") != std::string::npos);
     EXPECT_TRUE(light_output.find("INF") != std::string::npos);
 }
+
+TEST(TestEntries, DetailedEntryRendersPrefixAndFunction) {
+    LogEvent event;
+    event.level   = INF;
+    event.message = "with prefix";
+    event.prefix.assign(std::string_view{"MyClass"});
+    event.location        = detail::MetaSource{std::source_location::current()};
+    event.time_point      = detail::MetaTimePoint{};
+    event.tid             = detail::MetaThread{};
+    event.pid             = detail::MetaProcess{};
+    event.shutdown_signal = false;
+
+    auto entry = make_entry_from_event<DetailedEntry>(event);
+    std::string output;
+    entry.format_into(output);
+
+    EXPECT_NE(output.find("[MyClass:"), std::string::npos) << "prefix:function segment missing: " << output;
+    EXPECT_NE(output.find("with prefix"), std::string::npos);
+}
+
+TEST(TestEntries, DetailedEntryOmitsSegmentWhenPrefixEmpty) {
+    LogEvent event;
+    event.level           = INF;
+    event.message         = "no prefix";
+    event.location        = detail::MetaSource{std::source_location::current()};
+    event.time_point      = detail::MetaTimePoint{};
+    event.tid             = detail::MetaThread{};
+    event.pid             = detail::MetaProcess{};
+    event.shutdown_signal = false;
+
+    auto entry = make_entry_from_event<DetailedEntry>(event);
+    std::string output;
+    entry.format_into(output);
+
+    // Should not contain a [:name] style segment near the start
+    EXPECT_EQ(output.find("[:"), std::string::npos) << output;
+    EXPECT_NE(output.find("no prefix"), std::string::npos);
+}

--- a/tests/unit_tests/scroll/logger/logger_ordering_test.cpp
+++ b/tests/unit_tests/scroll/logger/logger_ordering_test.cpp
@@ -20,7 +20,7 @@ namespace {
         void flush() override {
         }
 
-        [[nodiscard]] bool should_log(demiplane::scroll::LogLevel) const noexcept override {
+        [[nodiscard]] bool should_log(demiplane::scroll::LogLevel, std::string_view) const noexcept override {
             return true;
         }
 
@@ -63,8 +63,9 @@ TEST(LoggerOrderingTest, DisruptorMaintainsSequenceOrder) {
             for (size_t i = 0; i < ENTRIES_PER_THREAD; ++i) {
                 // Use a dummy counter just for content, not for ordering verification
                 logger.log(demiplane::scroll::LogLevel::Info,
-                           "SEQ {}",
+                           std::string_view{},
                            std::source_location::current(),
+                           "SEQ {}",
                            ENTRIES_PER_THREAD * t + i);
             }
         });
@@ -113,7 +114,11 @@ TEST(LoggerOrderingTest, SequenceBasedLoggingIsStrictlyOrdered) {
                 int64_t seq = global_sequence.fetch_add(1, std::memory_order_seq_cst);
 
                 // Log with that sequence - now there's a happens-before relationship
-                logger.log(demiplane::scroll::LogLevel::Info, "SEQ {}", std::source_location::current(), seq);
+                logger.log(demiplane::scroll::LogLevel::Info,
+                           std::string_view{},
+                           std::source_location::current(),
+                           "SEQ {}",
+                           seq);
             }
         });
     }
@@ -165,7 +170,11 @@ TEST(LoggerOrderingTest, FileSinkPreservesConsumerOrder) {
         threads.emplace_back([&logger, &sequence]() {
             for (size_t i = 0; i < ENTRIES_PER_THREAD; ++i) {
                 int64_t seq = sequence.fetch_add(1, std::memory_order_seq_cst);
-                logger.log(demiplane::scroll::LogLevel::Info, "SEQ {}", std::source_location::current(), seq);
+                logger.log(demiplane::scroll::LogLevel::Info,
+                           std::string_view{},
+                           std::source_location::current(),
+                           "SEQ {}",
+                           seq);
             }
         });
     }
@@ -220,7 +229,11 @@ TEST(LoggerOrderingTest, HighContentionNoCorruption) {
         threads.emplace_back([&logger, &sequence]() {
             for (size_t i = 0; i < ENTRIES_PER_THREAD; ++i) {
                 int64_t seq = sequence.fetch_add(1, std::memory_order_seq_cst);
-                logger.log(demiplane::scroll::LogLevel::Info, "SEQ {}", std::source_location::current(), seq);
+                logger.log(demiplane::scroll::LogLevel::Info,
+                           std::string_view{},
+                           std::source_location::current(),
+                           "SEQ {}",
+                           seq);
                 // No sleep - maximum contention
             }
         });

--- a/tests/unit_tests/scroll/logger_provider_test.cpp
+++ b/tests/unit_tests/scroll/logger_provider_test.cpp
@@ -55,8 +55,8 @@ TEST(LoggerProviderTest, FormatStyleLogging) {
     std::string username = "alice";
     int count            = 42;
 
-    LOG_DIRECT_FMT_INF(logger, "User {} has {} items", username, count);
-    LOG_DIRECT_FMT_DBG(logger, "Debug message with value {}", 123);
+    LOG_DIRECT_FMT_INF(logger, "", "User {} has {} items", username, count);
+    LOG_DIRECT_FMT_DBG(logger, "", "Debug message with value {}", 123);
 
     logger->shutdown();
 
@@ -79,10 +79,10 @@ TEST(LoggerProviderTest, OverloadedMacros) {
     testing::internal::CaptureStdout();
 
     // Test stream style (0 args)
-    LOG_DIRECT_STREAM_INF(logger) << "Stream style message";
+    LOG_DIRECT_STREAM_INF(logger, "") << "Stream style message";
 
     // Test format style (1+ args)
-    LOG_DIRECT_FMT_INF(logger, "Format style message {}", 123);
+    LOG_DIRECT_FMT_INF(logger, "", "Format style message {}", 123);
 
     logger->shutdown();
 

--- a/tests/unit_tests/scroll/prefix_filter_test.cpp
+++ b/tests/unit_tests/scroll/prefix_filter_test.cpp
@@ -1,0 +1,47 @@
+#include <gtest/gtest.h>
+#include <prefix_filter.hpp>
+
+using demiplane::scroll::PrefixFilter;
+
+TEST(PrefixFilterTest, AllowAllAdmitsEverythingIncludingEmpty) {
+    PrefixFilter f;
+    EXPECT_TRUE(f.accepts("foo"));
+    EXPECT_TRUE(f.accepts("bar"));
+    EXPECT_TRUE(f.accepts(""));
+}
+
+TEST(PrefixFilterTest, AllowListAdmitsListedAndEmpty) {
+    auto f = PrefixFilter::allow({"Foo", "Bar"});
+    EXPECT_TRUE(f.accepts("Foo"));
+    EXPECT_TRUE(f.accepts("Bar"));
+    EXPECT_FALSE(f.accepts("Baz"));
+    EXPECT_TRUE(f.accepts("")) << "empty prefix admitted by default";
+}
+
+TEST(PrefixFilterTest, AllowListWithBlockEmptyRejectsEmpty) {
+    auto f = PrefixFilter::allow({"Foo"}).block_empty_prefix();
+    EXPECT_TRUE(f.accepts("Foo"));
+    EXPECT_FALSE(f.accepts("Bar"));
+    EXPECT_FALSE(f.accepts(""));
+}
+
+TEST(PrefixFilterTest, DenyListAdmitsEverythingExceptListed) {
+    auto f = PrefixFilter::deny({"Noisy"});
+    EXPECT_FALSE(f.accepts("Noisy"));
+    EXPECT_TRUE(f.accepts("Quiet"));
+    EXPECT_TRUE(f.accepts(""));
+}
+
+TEST(PrefixFilterTest, DenyListWithBlockEmptyRejectsEmpty) {
+    auto f = PrefixFilter::deny({"Noisy"}).block_empty_prefix();
+    EXPECT_FALSE(f.accepts("Noisy"));
+    EXPECT_TRUE(f.accepts("Quiet"));
+    EXPECT_FALSE(f.accepts(""));
+}
+
+TEST(PrefixFilterTest, HeterogeneousLookupAcceptsStringView) {
+    auto f = PrefixFilter::allow({"Foo"});
+    std::string_view sv{"Foo"};
+    EXPECT_TRUE(f.accepts(sv));
+    EXPECT_FALSE(f.accepts(std::string_view{"Bar"}));
+}

--- a/tests/unit_tests/scroll/prefix_integration_test.cpp
+++ b/tests/unit_tests/scroll/prefix_integration_test.cpp
@@ -1,0 +1,103 @@
+#include <algorithm>
+#include <demiplane/scroll>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <prefix_filter.hpp>
+
+namespace {
+
+    // Capture sink — records (prefix, message) pairs for everything that
+    // passes should_log. Threshold is ignored (caller controls via filter).
+    class CaptureSink final : public demiplane::scroll::Sink {
+    public:
+        explicit CaptureSink(demiplane::scroll::PrefixFilter filter = {})
+            : filter_{std::move(filter)} {
+        }
+
+        void process(const demiplane::scroll::LogEvent& event) override {
+            if (!should_log(event.level, event.prefix.view())) {
+                return;
+            }
+            std::lock_guard lock{mutex_};
+            entries_.emplace_back(std::string{event.prefix.view()}, event.message);
+        }
+
+        void flush() override {
+        }
+
+        [[nodiscard]] bool should_log(demiplane::scroll::LogLevel, std::string_view prefix) const noexcept override {
+            return filter_.accepts(prefix);
+        }
+
+        [[nodiscard]] std::vector<std::pair<std::string, std::string>> entries() const {
+            std::lock_guard lock{mutex_};
+            return entries_;
+        }
+
+    private:
+        demiplane::scroll::PrefixFilter filter_;
+        mutable std::mutex mutex_;
+        std::vector<std::pair<std::string, std::string>> entries_;
+    };
+
+    bool contains(const std::vector<std::pair<std::string, std::string>>& es,
+                  std::string_view prefix,
+                  std::string_view message) {
+        return std::ranges::any_of(es,
+                                   [&](const auto& pair) { return pair.first == prefix && pair.second == message; });
+    }
+
+}  // namespace
+
+TEST(PrefixIntegrationTest, TwoSinksSeeDifferentSubsetsOfSameStream) {
+    auto allow_foo = std::make_shared<CaptureSink>(demiplane::scroll::PrefixFilter::allow({"Foo"}));
+    auto deny_bar  = std::make_shared<CaptureSink>(demiplane::scroll::PrefixFilter::deny({"Bar"}));
+
+    demiplane::scroll::Logger logger;
+    logger.add_sink(allow_foo);
+    logger.add_sink(deny_bar);
+
+    logger.log(demiplane::scroll::LogLevel::Info, "Foo", "hi from foo");
+    logger.log(demiplane::scroll::LogLevel::Info, "Bar", "hi from bar");
+    logger.log(demiplane::scroll::LogLevel::Info, "Baz", "hi from baz");
+    logger.log(demiplane::scroll::LogLevel::Info, "", "hi from empty");
+
+    logger.shutdown();
+
+    const auto allow_entries = allow_foo->entries();
+    const auto deny_entries  = deny_bar->entries();
+
+    // allow_foo: only "Foo" and empty (default admits empty)
+    EXPECT_TRUE(contains(allow_entries, "Foo", "hi from foo"));
+    EXPECT_TRUE(contains(allow_entries, "", "hi from empty"));
+    EXPECT_FALSE(contains(allow_entries, "Bar", "hi from bar"));
+    EXPECT_FALSE(contains(allow_entries, "Baz", "hi from baz"));
+
+    // deny_bar: everything except "Bar"
+    EXPECT_TRUE(contains(deny_entries, "Foo", "hi from foo"));
+    EXPECT_TRUE(contains(deny_entries, "Baz", "hi from baz"));
+    EXPECT_TRUE(contains(deny_entries, "", "hi from empty"));
+    EXPECT_FALSE(contains(deny_entries, "Bar", "hi from bar"));
+}
+
+TEST(PrefixIntegrationTest, BlockEmptyPrefixRejectsUnprefixedLogs) {
+    auto sink = std::make_shared<CaptureSink>(demiplane::scroll::PrefixFilter::allow({"Foo"}).block_empty_prefix());
+
+    demiplane::scroll::Logger logger;
+    logger.add_sink(sink);
+
+    logger.log(demiplane::scroll::LogLevel::Info, "Foo", "yes");
+    logger.log(demiplane::scroll::LogLevel::Info, "", "no");
+
+    logger.shutdown();
+
+    const auto entries = sink->entries();
+    EXPECT_TRUE(contains(entries, "Foo", "yes"));
+    EXPECT_FALSE(contains(entries, "", "no"));
+}


### PR DESCRIPTION
```
- Expanded the logging system to include class or component prefix handling.
- Updated log macros, `DetailedEntry`, and logger interfaces to support the propagation of prefixes.
- Added both compile-time and runtime guards ensuring maximum prefix size constraints are respected.

```